### PR TITLE
feat: add M1 persistence and typed Remote foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+lib/
+coverage/
+*.tsbuildinfo
+*.tgz
+.DS_Store
+.playwright-mcp/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dsh-explain — DSH 学习模式插件（WIP）
 
-> 🚧 **状态：PRD P0 定稿候选 + 技术架构 v6，待 review，暂无功能代码。**
+> 🚧 **状态：PRD P0 定稿候选 + 技术架构 v6；M1 基础设施开发中。**
 > 产品需求见 [docs/PRD.md](docs/PRD.md)；技术方案见 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)。
 
 **一句话定位**：把多个 DSH 工作会话中值得学习的内容汇入用户唯一的全局学习线程，为每个来源会话保留至多一个活跃讲解，并用全局学习上下文持续适配用户的知识水平和讲解偏好。
@@ -33,9 +33,31 @@
 - [x] PRD P0 定稿候选：单一学习线程、按来源活跃讲解、自主调用预算、双触发压缩、全局 ExplainContext 和可自动验证的验收标准。
 - [x] 技术架构 v6：本地 SQLite、实体级并发、持久来源摘要、全局单飞与调用预算、压缩检查点、typed Remote 和 `conversation.view` 学习界面。
 - [x] UI 路径核验：沿用第一方 `ui-trajectory` 的 `ctx.slots.inject('conversation.view', ...)` 注册方式，无外部 UI 依赖。
-- [ ] 架构 review 通过。
-- [ ] M1 技术原型 → M2 P0 实现 → M3 发布门禁。
+- [x] M1 基础设施：独立插件构建、本地 SQLite schema、实体级 CAS、分页/长轮询和自动生成的 typed Remote。
+- [ ] M2 P0 运行时与学习视图 → M3 发布门禁。
 - [ ] 在 hub `catalog.source.json` 登记分类。
+
+M1 只建立持久层和 Host/Client RPC 基础，不观察工作回合、不调用模型，也不注册用户可见的学习 Tab；这些行为在 M2 一起接入，以便界面验收使用真实模型流程。
+
+## 本地开发
+
+仓库不从 npm 解析或发布私有 DSH 包。先准备已构建的 DSH 源码目录，再安装公开的构建依赖并建立本地链接：
+
+```sh
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm install
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link:check
+pnpm run test
+pnpm run typecheck
+pnpm run build
+```
+
+开发验收使用本地目录安装，不经过 npm：
+
+```sh
+dsh plugin --profile web add /absolute/path/to/dsh-explain
+dsh --profile web --dump-config
+dsh --profile web
+```
 
 ## 查重结论（2026-08-12）
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,4 @@
+# dsh-explain is one global host row with a paired Web client bundle.
+- insert:
+    - id: explain
+      name: dsh-explain

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,9 +114,10 @@ $DSH_HOME/dsh-explain/v1/thread.sqlite
 | `meta` | `schema_version`, `store_revision`, `next_ordinal` | 全局格式、CAS revision 与严格递增顺序 |
 | `runtime_state` | `first_explain_output_at`, `last_user_action_at`, `activity_generation`, `last_compacted_at`, `context_generation` | 30 分钟计时基线、用户操作代数和压缩脏代数 |
 | `topics` | `topic_id`, `topic_key UNIQUE`, `title`, `state`, `topic_revision`, `updated_at` | Topic 身份、`learning / mastered` 状态与实体级 CAS |
-| `explanations` | `explanation_id`, `topic_id`, `source_session_id`, `state`, `active_revision`, `covered_by_checkpoint_id`, `created_at`, `updated_at` | 每来源活跃槽、重讲 revision 与压缩覆盖状态 |
-| `entries` | `entry_id`, `ordinal UNIQUE`, `kind`, `explanation_id`, `topic_id`, `revision`, `source_*`, `payload_json`, `created_at`, `request_id UNIQUE` | append-only 的讲解、反馈与 Topic reopen 记录 |
-| `context_observations` | `observation_id`, `source_session_id`, `source_turn`, `kind`, `payload_json`, `confidence`, `covered_by_checkpoint_id`, `created_at` | 从有界来源 capsule 提取的对话偏好或 Topic 熟悉度，不保存原文 |
+| `explanations` | `explanation_id`, `topic_id`, `source_session_id`, `state`, `active_revision`, `rephrase_pending`, `created_at`, `updated_at` | 每来源活跃槽、重讲 revision 与持久化重讲待办 |
+| `entries` | `entry_id`, `ordinal UNIQUE`, `kind`, `explanation_id`, `topic_id`, `revision`, `source_*`, `payload_json`, `created_at` | append-only 的讲解、反馈与 Topic reopen 记录 |
+| `mutation_requests` | `request_id UNIQUE`, `fingerprint`, `entry_id`, `created_at` | feedback/reopen 的持久幂等账本；多个等价重讲请求可指向同一 entry |
+| `context_observations` | `observation_id`, `source_session_id`, `source_turn`, `kind`, `payload_json`, `confidence`, `created_at` | 从有界来源 capsule 提取的对话偏好或 Topic 熟悉度，不保存原文；覆盖关系只以 `observation_coverage` 为准 |
 | `context_checkpoints` | `checkpoint_id`, `generation`, `trigger`, `through_ordinal`, `context_json`, `created_at`, `request_id UNIQUE` | 可重建的 `ExplainContext` 快照与压缩调用元数据 |
 | `context_coverage` | `checkpoint_id`, `explanation_id UNIQUE` | 明确标记哪些已关闭 Explanation 被哪个检查点吸收 |
 | `observation_coverage` | `checkpoint_id`, `observation_id UNIQUE` | 明确标记哪些结构化观察被哪个检查点吸收 |
@@ -129,7 +130,7 @@ $DSH_HOME/dsh-explain/v1/thread.sqlite
 
 `auto_request_usage` 的占额是运行记账，不改变学习线程的 `store_revision`；插入占额或滚动清理后提高 view cursor，使 `explain.status()` 的剩余额度收敛。`started_at` 建立索引，计数范围严格为 `(now - 24h, now]`。旧行可以在预算检查事务中删除，不影响业务历史。
 
-一个 Explanation 只有在 `state = 'closed'` 时才能进入 `context_coverage`；context observation 生成后即可进入 `observation_coverage`。压缩事务先校验模型请求捕获的 `context_generation`、owner fencing token 和所有 Explanation 覆盖目标仍为 closed，再同时插入 checkpoint、写两类 coverage、更新 `covered_by_checkpoint_id` 与 `runtime_state`。失败或取消不会留下部分覆盖。
+一个 Explanation 只有在 `state = 'closed'` 时才能进入 `context_coverage`；context observation 生成后即可进入 `observation_coverage`。两张 coverage 表是唯一的覆盖关系来源。压缩事务先校验模型请求捕获的 `context_generation`、owner fencing token 和所有 Explanation 覆盖目标仍为 closed，再同时插入 checkpoint、写两类 coverage 并更新 `runtime_state`。失败或取消不会留下部分覆盖。
 
 ### 身份与 revision
 
@@ -303,7 +304,7 @@ Scheduler 全局最多持有一个 `AbortController` 和一个模型 promise。�
 
 ### 可压缩集合
 
-只有 `state = 'closed' AND covered_by_checkpoint_id IS NULL` 的 Explanation 和尚未覆盖的 context observations 可压缩。活跃 Explanation 的所有 revisions 与反馈始终逐字进入实时覆盖层，不受其创建时间影响。原始 entries 从不删除或改写；`threadPage` 也不读取 checkpoint 代替历史。
+只有 `state = 'closed'` 且在 `context_coverage` 中不存在记录的 Explanation，以及在 `observation_coverage` 中不存在记录的 context observation 可压缩。活跃 Explanation 的所有 revisions 与反馈始终逐字进入实时覆盖层，不受其创建时间影响。原始 entries 从不删除或改写；`threadPage` 也不读取 checkpoint 代替历史。
 
 Compactor 的输入是上一检查点、按时间排序的一批未覆盖 observations/Explanation，以及数据库生成的最新权威统计。批次按“完整压缩请求 + `maxCompactionOutputTokens` 不超过 `contextThresholdRatio`”动态选取；一次无法容纳时分批生成中间检查点，直到目标 explain 请求降到阈值以内或没有可压缩项。新检查点是完整快照而非增量补丁，成功后替代旧检查点进入模型请求。
 
@@ -393,7 +394,7 @@ interface RephraseDecision {
 
 ### ✗ not-understood
 
-事务先幂等追加 feedback entry，Topic 保持 `learning`，目标 Explanation 保持活跃，提高 `activityGeneration` 并更新 `last_user_action_at`；Scheduler 随即把该目标加入 rephrase 队列。成功后追加同一来源、同一 Explanation 的 `revision + 1`，更新 `topics.title` 与 `topicRevision`，新 revision 成为该来源唯一可反馈项。若该 revision 已有 not-understood entry 但重讲尚未成功，再次点击 ✗ 只重新调度，不追加重复反馈。
+事务先幂等追加 feedback entry，将目标 Explanation 的 `rephrase_pending` 设为 1，Topic 保持 `learning`，目标 Explanation 保持活跃，提高 `activityGeneration` 并更新 `last_user_action_at`；Scheduler 随即把该持久待办加入 rephrase 队列。成功后追加同一来源、同一 Explanation 的 `revision + 1`，清除 `rephrase_pending`，更新 `topics.title` 与 `topicRevision`，新 revision 成为该来源唯一可反馈项。若该 revision 已有 not-understood entry 但重讲尚未成功，再次点击 ✗ 只在 `mutation_requests` 中把新 RequestId 指向原 entry 并重新调度，不追加重复反馈；重启按 `rephrase_pending` 恢复，而不是从展示文本猜测待办。
 
 ### 撤销掌握
 
@@ -414,7 +415,7 @@ interface FeedbackRequest {
 ```
 
 - 同一 `requestId` 重放返回第一次结果。
-- 目标不是所声明来源的当前活跃 revision 时返回 `STALE_EXPLANATION_REVISION`，并带该来源当前状态供客户端刷新。
+- 目标不是所声明来源的当前活跃 revision 时返回 `STALE_EXPLANATION_REVISION`；客户端随后刷新 status 与最新页，不在失败对象中复制一份可能再次过期的来源状态。
 - 不同来源的反馈没有共享 expected-store gate，可以在各自事务中依次成功；同一 Explanation 的竞争由 active revision 和幂等约束裁决。
 - `reopenTopic` 携带 `expectedTopicRevision`；不匹配时返回 `STALE_TOPIC_REVISION`。
 - 事务成功后 Remote 返回新的 `storeRevision` 和受影响条目；客户端不得猜测最终状态。

--- a/package.json
+++ b/package.json
@@ -2,42 +2,97 @@
   "name": "dsh-explain",
   "version": "0.1.0",
   "private": true,
+  "description": "Private DSH learning-mode plugin with a global local-first learning thread.",
   "type": "module",
   "main": "./lib/index.js",
+  "types": "./lib/types/index.d.ts",
   "exports": {
-    ".": "./lib/index.js",
-    "./client": "./lib/client.js",
-    "./invariant": "./lib/invariant.js",
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./client": {
+      "types": "./lib/client/index.d.ts",
+      "default": "./lib/client.js"
+    },
+    "./types": {
+      "types": "./lib/types/types.d.ts",
+      "default": "./lib/types/types.js"
+    },
+    "./typert": {
+      "types": "./lib/typert.host.d.ts",
+      "default": "./lib/typert.host.js"
+    },
+    "./remote": {
+      "types": "./lib/typert.remote-client.d.ts",
+      "default": "./lib/typert.remote-client.js"
+    },
     "./package.json": "./package.json"
   },
+  "files": [
+    "lib/index.js",
+    "lib/types/index.d.ts",
+    "lib/client.js",
+    "lib/client/**/*.d.ts",
+    "lib/types/**/*.js",
+    "lib/types/**/*.d.ts",
+    "lib/typert.host.js",
+    "lib/typert.host.d.ts",
+    "lib/typert.remote-client.js",
+    "lib/typert.remote-client.d.ts",
+    "lib/typert.remote-client.d.ts.map",
+    "cordis.patch.yml"
+  ],
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
     },
     "client": {
-      "platform": "web",
-      "inject": [
-        "@deepseek-ai/dsh-client-locale",
-        "@deepseek-ai/dsh-client-runtime",
-        "@deepseek-ai/dsh-client-ui-conversation"
-      ]
+      "platform": "web"
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && tsdown",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "clean": "node scripts/clean.mjs",
+    "dsh:link": "node scripts/setup-dsh-links.mjs",
+    "dsh:link:check": "node scripts/setup-dsh-links.mjs --check",
+    "build:host": "tsc -p tsconfig.build.json && node scripts/generate-typert.mjs && tsdown",
+    "build:client": "node scripts/build-client.mjs",
+    "build": "pnpm clean && pnpm build:host && pnpm build:client",
+    "typecheck": "pnpm build:host && tsc -p tsconfig.host.json --noEmit && tsc -p tsconfig.client.json --noEmit && tsc -p tsconfig.spec.json --noEmit",
+    "test": "vitest run",
+    "prepare": "node scripts/setup-dsh-links.mjs && pnpm build",
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
-    "@deepseek-ai/dsh-client-locale": "0.0.1-rc.1",
-    "@deepseek-ai/dsh-client-runtime": "0.0.1-rc.1",
-    "@deepseek-ai/dsh-client-ui-conversation": "0.0.1-rc.1",
-    "@deepseek-ai/dsh-client-ui-slots": "0.0.1-rc.1",
-    "@deepseek-ai/dsh-llm": "0.0.1-rc.1",
-    "@deepseek-ai/dsh-session": "0.0.1-rc.1",
-    "@deepseek-ai/dsh-settings": "0.0.1-rc.1",
-    "@deepseek-ai/dsh-token-meter": "0.0.1-rc.1",
-    "cordis": "^4.0.0-rc.7",
-    "react": "^18.2.0"
-  }
+    "@deepseek-ai/cordis": "^4.0.1-rc.1",
+    "@deepseek-ai/dsh-api-gateway": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-type-meta": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-typert-generator": "^0.0.1-rc.1",
+    "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^26.2.0",
+    "@types/react": "~18.3.1",
+    "@types/react-dom": "~18.3.7",
+    "esbuild": "^0.28.2",
+    "jsdom": "29.1.1",
+    "lightningcss": "^1.33.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.3.1",
+    "tsdown": "^0.20.1",
+    "typescript": "^6.0.3",
+    "vitest": "^3.2.4"
+  },
+  "engines": {
+    "node": "^22.19 || >=24"
+  },
+  "license": "BSD-3-Clause",
+  "packageManager": "pnpm@11.7.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2423 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
+      '@types/react':
+        specifier: ~18.3.1
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ~18.3.7
+        version: 18.3.7(@types/react@18.3.31)
+      esbuild:
+        specifier: ^0.28.2
+        version: 0.28.2
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1
+      lightningcss:
+        specifier: ^1.33.0
+        version: 1.33.0
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      tsdown:
+        specifier: ^0.20.1
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@26.2.0)(jsdom@29.1.1)(lightningcss@1.33.0)
+
+packages:
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@8.0.0-rc.2':
+    resolution: {integrity: sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.2':
+    resolution: {integrity: sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/parser@8.0.0-rc.2':
+    resolution: {integrity: sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0-rc.2':
+    resolution: {integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@oxc-project/types@0.112.0':
+    resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.3':
+    resolution: {integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
+    resolution: {integrity: sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.3':
+    resolution: {integrity: sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
+    resolution: {integrity: sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
+    resolution: {integrity: sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
+    resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
+    resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
+    resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
+    resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
+    resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
+    resolution: {integrity: sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
+    resolution: {integrity: sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
+    resolution: {integrity: sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
+    engines: {node: '>=14'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-kit@3.0.0:
+    resolution: {integrity: sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  birpc@4.1.0:
+    resolution: {integrity: sha512-O8L9vALWGqdEe0cG4HJckauw3WeJETlJnDRPUYpgwB7wrU43b/5NGMdVjdVcRo+4ROgd3ih2wha1glDe4HRVgw==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dts-resolver@2.1.3:
+    resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.1:
+    resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  import-without-cache@0.2.5:
+    resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
+    engines: {node: '>=20.19.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rolldown-plugin-dts@0.22.5:
+    resolution: {integrity: sha512-M/HXfM4cboo+jONx9Z0X+CUf3B5tCi7ni+kR5fUW50Fp9AlZk0oVLesibGWgCXDKFp5lpgQ9yhKoImUFjl3VZw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-rc.3
+      typescript: ^5.0.0 || ^6.0.0-beta
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.0-rc.3:
+    resolution: {integrity: sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  tsdown@0.20.3:
+    resolution: {integrity: sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@vitejs/devtools': '*'
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  unrun@0.2.39:
+    resolution: {integrity: sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/generator@8.0.0-rc.2':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
+  '@babel/helper-string-parser@8.0.0': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.2': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
+
+  '@babel/parser@8.0.0-rc.2':
+    dependencies:
+      '@babel/types': 8.0.0-rc.2
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
+
+  '@babel/runtime@7.29.7': {}
+
+  '@babel/types@8.0.0-rc.2':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.0-rc.2
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@exodus/bytes@1.15.1': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.112.0': {}
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/jsesc@2.5.1': {}
+
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  ansis@4.3.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  assertion-error@2.0.1: {}
+
+  ast-kit@3.0.0:
+    dependencies:
+      '@babel/parser': 8.0.4
+      estree-walker: 3.0.3
+      pathe: 2.0.3
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  birpc@4.1.0: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
+  defu@6.1.7: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dts-resolver@2.1.3: {}
+
+  empathic@2.0.1: {}
+
+  entities@8.0.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  hookable@6.1.1: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  import-without-cache@0.2.5: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.29.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  jsesc@3.1.0: {}
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
+
+  lru-cache@11.5.2: {}
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  obug@2.1.4: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  quansync@1.0.0: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-is@17.0.2: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  require-from-string@2.0.2: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
+      ast-kit: 3.0.0
+      birpc: 4.1.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.14.1
+      obug: 2.1.4
+      rolldown: 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      '@oxc-project/types': 0.112.0
+      '@rolldown/pluginutils': 1.0.0-rc.3
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.3
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.3
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.3
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.3
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.3
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.3
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@7.8.5: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
+
+  tsdown@0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@6.0.3):
+    dependencies:
+      ansis: 4.3.1
+      cac: 6.7.14
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.2.5
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      semver: 7.8.5
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      unrun: 0.2.39
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  unconfig-core@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
+
+  undici-types@8.3.0: {}
+
+  undici@7.29.0: {}
+
+  unrun@0.2.39:
+    dependencies:
+      rolldown: 1.0.0-rc.17
+
+  vite-node@3.2.4(@types/node@26.2.0)(lightningcss@1.33.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      fsevents: 2.3.3
+      lightningcss: 1.33.0
+
+  vitest@3.2.7(@types/node@26.2.0)(jsdom@29.1.1)(lightningcss@1.33.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)
+      vite-node: 3.2.4(@types/node@26.2.0)(lightningcss@1.33.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - .
+
+# DSH packages are private source links created by scripts/setup-dsh-links.mjs.
+# They must never be resolved from or published to a package registry.
+autoInstallPeers: false
+verifyDepsBeforeRun: false
+
+allowBuilds:
+  esbuild: true

--- a/scripts/build-client.mjs
+++ b/scripts/build-client.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { build } from 'esbuild'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const output = resolve(repository, 'lib', 'client.js')
+const platformModules = [
+  'react',
+  'react/jsx-runtime',
+  '@deepseek-ai/cordis',
+  '@deepseek-ai/dsh-client-runtime/client',
+  '@deepseek-ai/dsh-client-ui-slots',
+  '@deepseek-ai/dsh-client-ui-primitives',
+  '@deepseek-ai/dsh-client-web-react',
+]
+
+if (!existsSync(resolve(repository, 'lib', 'typert.remote-client.js'))) {
+  throw new Error('client build requires generated lib/typert.remote-client.js; run build:host first')
+}
+
+await build({
+  absWorkingDir: repository,
+  entryPoints: ['src/client/index.ts'],
+  outfile: output,
+  bundle: true,
+  format: 'cjs',
+  platform: 'browser',
+  target: ['es2022'],
+  sourcemap: true,
+  external: platformModules,
+  banner: {
+    js: 'window.__ModuleLoader__.load({ id: "dsh-explain", factory: (require) => { var module = { exports: {} }; var exports = module.exports;',
+  },
+  footer: { js: 'return module.exports; } });' },
+  define: { 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'production') },
+  logLevel: 'info',
+})
+
+const bundle = readFileSync(output, 'utf8')
+if (
+  !bundle.includes('window.__ModuleLoader__.load(')
+  || !bundle.includes('var module = { exports: {} }')
+  || !bundle.includes('dsh-explain')
+) {
+  throw new Error('dsh-explain: client bundle is missing the ModuleLoader handoff')
+}
+if (bundle.includes('import.meta') || /(^|\n)\s*(import|export)\s/.test(bundle)) {
+  throw new Error('dsh-explain: client bundle contains ESM syntax')
+}
+for (const match of bundle.matchAll(/require\(\s*["'](@deepseek-ai\/[^"']+)["']\s*\)/g)) {
+  if (!platformModules.includes(match[1])) {
+    throw new Error(`dsh-explain: unsupported client runtime dependency ${match[1]}`)
+  }
+}
+
+const require = createRequire(import.meta.url)
+const tsc = require.resolve('typescript/bin/tsc')
+rmSync(resolve(repository, 'lib', 'client'), { recursive: true, force: true })
+const declarations = spawnSync(process.execPath, [tsc, '-p', 'tsconfig.client.json'], {
+  cwd: repository,
+  encoding: 'utf8',
+})
+if (declarations.status !== 0) {
+  throw new Error(`client declaration build failed:\n${declarations.stdout}${declarations.stderr}`)
+}

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { rmSync } from 'node:fs'
+
+for (const target of ['lib', 'coverage', 'tsconfig.host.tsbuildinfo']) {
+  rmSync(target, { force: true, recursive: true })
+}

--- a/scripts/generate-typert.mjs
+++ b/scripts/generate-typert.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { WorkspaceTypertGenerator } from '@deepseek-ai/dsh-typert-generator'
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const workspace = mkdtempSync(join(tmpdir(), 'dsh-explain-typert-'))
+const packageRoot = join(workspace, 'packages', 'dsh-explain')
+const typeMetaRoot = join(workspace, 'packages', 'typert', 'type-meta')
+const dshSource = resolve(repository, 'node_modules', '@deepseek-ai', 'dsh-type-meta')
+
+try {
+  mkdirSync(packageRoot, { recursive: true })
+  cpSync(join(repository, 'src'), join(packageRoot, 'src'), { recursive: true })
+  rmSync(join(packageRoot, 'src', 'client'), { recursive: true, force: true })
+  mkdirSync(typeMetaRoot, { recursive: true })
+  cpSync(join(dshSource, 'src'), join(typeMetaRoot, 'src'), { recursive: true })
+  const typeMetaManifest = JSON.parse(readFileSync(join(dshSource, 'package.json'), 'utf8'))
+  typeMetaManifest.exports = { '.': './src/index.ts' }
+  writeFileSync(join(typeMetaRoot, 'package.json'), `${JSON.stringify(typeMetaManifest, null, 2)}\n`)
+  writeFileSync(join(typeMetaRoot, 'tsconfig.json'), `${JSON.stringify({
+    compilerOptions: {
+      target: 'ES2024',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+    },
+    include: ['src'],
+  }, null, 2)}\n`)
+  const manifest = JSON.parse(readFileSync(join(repository, 'package.json'), 'utf8'))
+  manifest.exports = {
+    '.': './src/index.ts',
+    './types': './src/types.ts',
+    './typert': {
+      types: './lib/typert.host.d.ts',
+      default: './lib/typert.host.js',
+    },
+    './remote': {
+      types: './lib/typert.remote-client.d.ts',
+      default: './lib/typert.remote-client.js',
+    },
+  }
+  writeFileSync(join(packageRoot, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  writeFileSync(join(packageRoot, 'tsconfig.json'), `${JSON.stringify({
+    compilerOptions: {
+      target: 'ES2024',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      lib: ['ES2024'],
+      types: ['node'],
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      allowImportingTsExtensions: true,
+      rewriteRelativeImportExtensions: true,
+      baseUrl: '.',
+      paths: {
+        '@deepseek-ai/dsh-type-meta': ['../typert/type-meta/src/index.ts'],
+      },
+      useDefineForClassFields: true,
+    },
+    include: ['src'],
+  }, null, 2)}\n`)
+  writeFileSync(join(workspace, 'tsconfig.host.json'), `${JSON.stringify({
+    compilerOptions: {
+      target: 'ES2024',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      baseUrl: '.',
+      paths: {
+        '@deepseek-ai/dsh-type-meta': ['packages/typert/type-meta/src/index.ts'],
+      },
+    },
+    files: [],
+    references: [
+      { path: './packages/dsh-explain' },
+      { path: './packages/typert/type-meta' },
+    ],
+  }, null, 2)}\n`)
+  symlinkSync(join(repository, 'node_modules'), join(workspace, 'node_modules'), 'dir')
+
+  const generator = new WorkspaceTypertGenerator(workspace)
+  const discovered = generator.discover(['host'])
+  const artifacts = generator.generate(['dsh-explain'], ['host'])
+  const artifact = artifacts.find(candidate => candidate.package === 'dsh-explain' && candidate.face === 'host')
+  if (artifact === undefined || artifact.remote === undefined) {
+    const summary = artifacts.map(candidate => ({
+      package: candidate.package,
+      face: candidate.face,
+      remote: candidate.remote !== undefined,
+    }))
+    throw new Error(`TypeRT generator did not emit the dsh-explain host and Remote artifacts: ${JSON.stringify({ discovered, artifacts: summary })}`)
+  }
+  mkdirSync(join(repository, 'lib'), { recursive: true })
+  writeFileSync(join(repository, 'lib', 'typert.host.js'), artifact.js)
+  writeFileSync(join(repository, 'lib', 'typert.host.d.ts'), artifact.dts)
+  writeFileSync(join(repository, 'lib', 'typert.remote-client.js'), artifact.remote.js)
+  writeFileSync(join(repository, 'lib', 'typert.remote-client.d.ts'), artifact.remote.dts)
+  writeFileSync(join(repository, 'lib', 'typert.remote-client.d.ts.map'), artifact.remote.dtsMap)
+  console.log('generated TypeRT host and Remote artifacts')
+} finally {
+  rmSync(workspace, { recursive: true, force: true })
+}

--- a/scripts/setup-dsh-links.mjs
+++ b/scripts/setup-dsh-links.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const checkOnly = process.argv.includes('--check')
+
+function readDirectories(directory) {
+  try {
+    return readdirSync(directory, { withFileTypes: true })
+      .filter(entry => entry.isDirectory() && !entry.name.startsWith('.'))
+      .map(entry => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function resolveSourceRoot() {
+  const candidates = [
+    process.env.DSH_SOURCE_DIR,
+    process.env.DSH_HOME === undefined ? undefined : join(process.env.DSH_HOME, 'source', 'current'),
+    process.env.HOME === undefined ? undefined : join(process.env.HOME, '.dsh', 'source', 'current'),
+  ].filter(candidate => candidate !== undefined)
+  const found = candidates.find(candidate => existsSync(join(candidate, 'packages')) && existsSync(join(candidate, 'vendor')))
+  if (found === undefined) {
+    throw new Error(`no DSH source tree found; set DSH_SOURCE_DIR (tried ${candidates.join(', ')})`)
+  }
+  return resolve(found)
+}
+
+function collectPackages(sourceRoot) {
+  const packages = new Map()
+  for (const area of ['packages', 'vendor']) {
+    const areaRoot = join(sourceRoot, area)
+    for (const first of readDirectories(areaRoot)) {
+      const direct = join(areaRoot, first)
+      const candidates = existsSync(join(direct, 'package.json')) ? [direct] : []
+      for (const second of readDirectories(direct)) {
+        const grouped = join(direct, second)
+        if (existsSync(join(grouped, 'package.json'))) candidates.push(grouped)
+      }
+      for (const candidate of candidates) {
+        const manifest = JSON.parse(readFileSync(join(candidate, 'package.json'), 'utf8'))
+        if (typeof manifest.name === 'string' && manifest.name.startsWith('@deepseek-ai/')) {
+          packages.set(manifest.name, candidate)
+        }
+      }
+    }
+  }
+  return packages
+}
+
+function requiredPeers() {
+  const manifest = JSON.parse(readFileSync(join(repository, 'package.json'), 'utf8'))
+  return Object.keys(manifest.peerDependencies ?? {})
+    .filter(name => name.startsWith('@deepseek-ai/') && name !== '@deepseek-ai/cordis')
+    .sort()
+}
+
+function linkKind() {
+  return process.platform === 'win32' ? 'junction' : 'dir'
+}
+
+function replaceLink(linkPath, target) {
+  rmSync(linkPath, { force: true, recursive: true })
+  mkdirSync(dirname(linkPath), { recursive: true })
+  symlinkSync(target, linkPath, linkKind())
+}
+
+function linkProblem(linkPath, target) {
+  if (!existsSync(linkPath)) return 'missing'
+  try {
+    return resolve(dirname(linkPath), readlinkSync(linkPath)) === resolve(target) ? undefined : 'stale target'
+  } catch {
+    return 'not a symlink'
+  }
+}
+
+function writeCordisShim(sourceRoot) {
+  const target = join(sourceRoot, 'vendor', 'cordis')
+  const manifest = JSON.parse(readFileSync(join(target, 'package.json'), 'utf8'))
+  if (manifest.name !== '@deepseek-ai/cordis') throw new Error(`unexpected Cordis package name ${String(manifest.name)}`)
+  const shim = join(repository, 'node_modules', '@deepseek-ai', 'cordis')
+  rmSync(shim, { force: true, recursive: true })
+  mkdirSync(shim, { recursive: true })
+  replaceLink(join(shim, 'index.js'), join(target, 'lib', 'index.js'))
+  replaceLink(join(shim, 'index.d.ts'), join(target, 'lib', 'types', 'index.d.ts'))
+  if (existsSync(join(target, 'src'))) replaceLink(join(shim, 'src'), join(target, 'src'))
+  writeFileSync(join(shim, 'package.json'), `${JSON.stringify({
+    name: '@deepseek-ai/cordis',
+    version: manifest.version,
+    private: true,
+    type: 'module',
+    main: './index.js',
+    types: './index.d.ts',
+    exports: {
+      '.': { types: './index.d.ts', default: './index.js' },
+      './src/*': './src/*',
+      './package.json': './package.json',
+    },
+  }, null, 2)}\n`)
+}
+
+function cordisProblem(sourceRoot) {
+  const shim = join(repository, 'node_modules', '@deepseek-ai', 'cordis')
+  const target = join(sourceRoot, 'vendor', 'cordis')
+  return linkProblem(join(shim, 'index.js'), join(target, 'lib', 'index.js'))
+    ?? linkProblem(join(shim, 'index.d.ts'), join(target, 'lib', 'types', 'index.d.ts'))
+}
+
+function reactIdentity(sourceRoot) {
+  const reactRequire = createRequire(join(sourceRoot, 'packages', 'client', 'web-react', 'package.json'))
+  const domRequire = createRequire(join(sourceRoot, 'packages', 'client', 'ui-primitives', 'package.json'))
+  return new Map([
+    ['react', dirname(reactRequire.resolve('react/package.json'))],
+    ['react-dom', dirname(domRequire.resolve('react-dom/package.json'))],
+  ])
+}
+
+function main() {
+  const sourceRoot = resolveSourceRoot()
+  const available = collectPackages(sourceRoot)
+  const missing = requiredPeers().filter(name => !available.has(name))
+  if (missing.length > 0) throw new Error(`DSH source tree is missing peers: ${missing.join(', ')}`)
+  const links = new Map(requiredPeers().map(name => [name, available.get(name)]))
+  for (const identity of reactIdentity(sourceRoot)) links.set(...identity)
+
+  if (checkOnly) {
+    const problems = []
+    for (const [name, target] of links) {
+      const problem = linkProblem(join(repository, 'node_modules', name), target)
+      if (problem !== undefined) problems.push(`${name}: ${problem}`)
+    }
+    const cordis = cordisProblem(sourceRoot)
+    if (cordis !== undefined) problems.push(`@deepseek-ai/cordis: ${cordis}`)
+    if (problems.length > 0) throw new Error(`DSH link check failed:\n  ${problems.join('\n  ')}`)
+    console.log(`DSH link farm ok: ${links.size + 1} packages from ${sourceRoot}`)
+    return
+  }
+
+  for (const [name, target] of links) replaceLink(join(repository, 'node_modules', name), target)
+  writeCordisShim(sourceRoot)
+  rmSync(join(repository, 'node_modules', 'cordis'), { force: true, recursive: true })
+  console.log(`DSH link farm: ${links.size + 1} packages from ${sourceRoot}`)
+}
+
+try {
+  main()
+} catch (error) {
+  process.stderr.write(`dsh-explain link setup failed: ${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+}

--- a/src/brands.ts
+++ b/src/brands.ts
@@ -1,0 +1,37 @@
+import type { Branded } from '@deepseek-ai/dsh-brand'
+
+/** Stable identity of one learned topic. */
+export type TopicId = Branded<'dsh-explain/topic'>
+
+/** Stable identity of one explanation and its rephrase revisions. */
+export type ExplanationId = Branded<'dsh-explain/explanation'>
+
+/** Stable identity of one append-only learning-thread entry. */
+export type EntryId = Branded<'dsh-explain/entry'>
+
+/** Stable identity of one structured ExplainContext observation. */
+export type ObservationId = Branded<'dsh-explain/observation'>
+
+/** Client-generated idempotency identity for one feedback mutation. */
+export type RequestId = Branded<'dsh-explain/request'>
+
+/** Host-generated identity for one accepted autonomous model request. */
+export type AutoRequestId = Branded<'dsh-explain/auto-request'>
+
+/** Construct a TopicId after persistence-boundary validation. */
+export const TopicId = (value: string): TopicId => value as TopicId
+
+/** Construct an ExplanationId after persistence-boundary validation. */
+export const ExplanationId = (value: string): ExplanationId => value as ExplanationId
+
+/** Construct an EntryId after persistence-boundary validation. */
+export const EntryId = (value: string): EntryId => value as EntryId
+
+/** Construct an ObservationId after persistence-boundary validation. */
+export const ObservationId = (value: string): ObservationId => value as ObservationId
+
+/** Construct a RequestId after wire-boundary validation. */
+export const RequestId = (value: string): RequestId => value as RequestId
+
+/** Construct an AutoRequestId after persistence-boundary validation. */
+export const AutoRequestId = (value: string): AutoRequestId => value as AutoRequestId

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,13 @@
+/** Browser half: mount dsh-explain's generated typed Remote contribution. */
+import type { Context } from '@deepseek-ai/cordis'
+import explainRemote from 'dsh-explain/remote'
+import type {} from '@deepseek-ai/dsh-api-gateway/client'
+import type {} from 'dsh-explain/remote'
+
+/** Required service: the TypeRT Client Remote registry and caller. */
+export const inject = ['remote']
+
+/** Mount the generated strict codecs for the explain namespace. */
+export async function apply(ctx: Context): Promise<() => Promise<void>> {
+  return await ctx.remote.$mount(explainRemote)
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,81 @@
+import { homedir } from 'node:os'
+import { isAbsolute, resolve } from 'node:path'
+import z from '@deepseek-ai/schemastery'
+
+/** Loader and settings configuration owned by dsh-explain. */
+export interface ExplainConfig {
+  readonly enabled?: boolean
+  readonly provider?: string
+  readonly model?: string
+  readonly dshHome?: string
+  readonly storageDir?: string
+  readonly maxPendingCandidates?: number
+  readonly maxSourceChars?: number
+  readonly maxAutoRequestsPerDay?: number
+  readonly maxTopicHints?: number
+  readonly idleCompactMs?: number
+  readonly contextThresholdRatio?: number
+  readonly timeoutMs?: number
+  readonly maxOutputTokens?: number
+  readonly maxCompactionOutputTokens?: number
+  readonly maxAttempts?: number
+}
+
+/** Runtime configuration with an absolute SQLite path. */
+export interface ResolvedExplainConfig extends Required<Omit<ExplainConfig, 'provider' | 'model'>> {
+  readonly provider?: string
+  readonly model?: string
+  readonly databasePath: string
+}
+
+/** Loader schema with every deployment tunable defined in architecture v6. */
+export const Config = z.object({
+  enabled: z.boolean().default(false),
+  provider: z.string(),
+  model: z.string(),
+  dshHome: z.string(),
+  storageDir: z.string(),
+  maxPendingCandidates: z.number().step(1).min(1).default(8),
+  maxSourceChars: z.number().step(1).min(1).default(24_000),
+  maxAutoRequestsPerDay: z.number().step(1).min(1).default(50),
+  maxTopicHints: z.number().step(1).min(1).default(100),
+  idleCompactMs: z.number().step(1).min(1).default(1_800_000),
+  contextThresholdRatio: z.number().min(0.01).max(0.99).default(0.5),
+  timeoutMs: z.number().step(1).min(1).default(30_000),
+  maxOutputTokens: z.number().step(1).min(1).default(1_200),
+  maxCompactionOutputTokens: z.number().step(1).min(1).default(1_600),
+  maxAttempts: z.number().step(1).min(1).default(2),
+})
+
+const CONFIG_KEYS = new Set([
+  'enabled', 'provider', 'model', 'dshHome', 'storageDir', 'maxPendingCandidates', 'maxSourceChars',
+  'maxAutoRequestsPerDay', 'maxTopicHints', 'idleCompactMs', 'contextThresholdRatio', 'timeoutMs',
+  'maxOutputTokens', 'maxCompactionOutputTokens', 'maxAttempts',
+])
+
+/** Validate Loader input and resolve its one immutable database path. */
+export function resolveExplainConfig(input: ExplainConfig): ResolvedExplainConfig {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('dsh-explain: configuration must be a plain object')
+  }
+  for (const key of Object.keys(input)) {
+    if (!CONFIG_KEYS.has(key)) throw new Error(`dsh-explain: unknown config key "${key}"`)
+  }
+  const config = Config(input)
+  const dshHome = config.dshHome?.trim() || process.env.DSH_HOME || resolve(homedir(), '.dsh')
+  const storageDir = config.storageDir?.trim()
+  const provider = config.provider?.trim()
+  const model = config.model?.trim()
+  const directory = storageDir === undefined || storageDir === ''
+    ? resolve(dshHome, 'dsh-explain', 'v1')
+    : isAbsolute(storageDir) ? storageDir : resolve(dshHome, storageDir)
+  const { provider: _provider, model: _model, ...base } = config
+  return {
+    ...base,
+    ...(provider === undefined || provider === '' ? {} : { provider }),
+    ...(model === undefined || model === '' ? {} : { model }),
+    dshHome,
+    storageDir: directory,
+    databasePath: resolve(directory, 'thread.sqlite'),
+  }
+}

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,0 +1,86 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { GatewayService, Remote } from '@deepseek-ai/dsh-type-meta'
+import type { ResolvedExplainConfig } from './config.ts'
+import type { ExplainStore } from './store.ts'
+import type {
+  ExplainContextView,
+  ExplainStatusView,
+  FeedbackMutationResult,
+  FeedbackRequest,
+  ReopenTopicRequest,
+  ReopenTopicResult,
+  ThreadPageRequest,
+  ThreadPageResult,
+  WatchRequest,
+  WatchResult,
+} from './types.ts'
+
+/** Host-side typed Remote service for the global learning thread. */
+export class ExplainGateway extends GatewayService {
+  /** Register the explain namespace against one store and live config source. */
+  constructor(
+    ctx: Context,
+    private readonly store: ExplainStore,
+    private readonly config: () => ResolvedExplainConfig,
+  ) {
+    super(ctx, 'explain')
+  }
+
+  /** Read runtime, queue, budget, and persistence status. */
+  @Remote
+  status(): ExplainStatusView {
+    const config = this.config()
+    return {
+      enabled: config.enabled,
+      runtimeState: config.enabled ? 'ready' : 'disabled',
+      activeExplanationCount: this.store.activeExplanationCount(),
+      pendingCandidateCount: 0,
+      autoRequestsUsed: this.store.autoRequestsUsed(),
+      autoRequestsLimit: config.maxAutoRequestsPerDay,
+      storeRevision: this.store.storeRevision(),
+      cursor: this.store.cursor(),
+    }
+  }
+
+  /** Read one backward page from the append-only learning thread. */
+  @Remote
+  threadPage(request: ThreadPageRequest): ThreadPageResult {
+    return this.store.threadPage(request)
+  }
+
+  /** Read the latest ExplainContext projection and authoritative statistics. */
+  @Remote
+  context(): ExplainContextView {
+    return this.store.context()
+  }
+
+  /** Wait for a view revision change or the ordinary long-poll timeout. */
+  @Remote
+  watch(request: WatchRequest, signal: AbortSignal): Promise<WatchResult> {
+    return this.store.watch(request.after, signal)
+  }
+
+  /** Submit entity-scoped understood or not-understood feedback. */
+  @Remote
+  feedback(request: FeedbackRequest): FeedbackMutationResult {
+    if (!this.config().enabled) {
+      return {
+        ok: false,
+        error: { code: 'EXPLAIN_DISABLED', message: 'Learning mode is disabled.' },
+      }
+    }
+    return this.store.feedback(request)
+  }
+
+  /** Reopen one mastered Topic with Topic revision CAS. */
+  @Remote
+  reopenTopic(request: ReopenTopicRequest): ReopenTopicResult {
+    if (!this.config().enabled) {
+      return {
+        ok: false,
+        error: { code: 'EXPLAIN_DISABLED', message: 'Learning mode is disabled.' },
+      }
+    }
+    return this.store.reopenTopic(request)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,39 @@
+/**
+ * dsh-explain host plugin: one global SQLite learning thread and its typed Remote service.
+ * @module dsh-explain
+ */
+import type { Context } from '@deepseek-ai/cordis'
+import { resolveExplainConfig, type ExplainConfig } from './config.ts'
+import { ExplainGateway } from './gateway.ts'
+import { ExplainStore } from './store.ts'
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    /** Host-side global learning-thread Remote service. */
+    explain: ExplainGateway
+  }
+}
+
+export const name = 'dsh-explain'
+
+/** M1 has no host service dependency; later P0 phases add Session, LLM, token-meter, and settings consumers. */
+export const inject: string[] = []
+
+export { Config } from './config.ts'
+export type { ExplainConfig, ResolvedExplainConfig } from './config.ts'
+export { ExplainGateway } from './gateway.ts'
+export * from './brands.ts'
+export type * from './types.ts'
+
+/** Open the global store, publish its Remote service, and bind database closure to the plugin fiber. */
+export function apply(ctx: Context, config: ExplainConfig): void {
+  const resolved = resolveExplainConfig(config)
+  const store = new ExplainStore(resolved.databasePath)
+  try {
+    new ExplainGateway(ctx, store, () => resolved)
+  } catch (error) {
+    store.close()
+    throw error
+  }
+  ctx.effect(() => () => { store.close() }, 'dsh-explain: close SQLite store')
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,130 @@
+/** Initial dsh-explain SQLite format. Pre-release builds reject every other version. */
+export const SCHEMA_VERSION = 1
+
+/** Complete schema installed atomically for a new database. */
+export const CREATE_SCHEMA_SQL = `
+CREATE TABLE meta (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  schema_version INTEGER NOT NULL,
+  store_revision INTEGER NOT NULL CHECK (store_revision >= 0),
+  next_ordinal INTEGER NOT NULL CHECK (next_ordinal >= 1)
+) STRICT;
+
+CREATE TABLE runtime_state (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  first_explain_output_at INTEGER,
+  last_user_action_at INTEGER,
+  activity_generation INTEGER NOT NULL DEFAULT 0 CHECK (activity_generation >= 0),
+  last_compacted_at INTEGER,
+  context_generation INTEGER NOT NULL DEFAULT 0 CHECK (context_generation >= 0)
+) STRICT;
+
+CREATE TABLE topics (
+  topic_id TEXT PRIMARY KEY,
+  topic_key TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('learning', 'mastered')),
+  topic_revision INTEGER NOT NULL CHECK (topic_revision >= 1),
+  updated_at INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE explanations (
+  explanation_id TEXT PRIMARY KEY,
+  topic_id TEXT NOT NULL REFERENCES topics(topic_id),
+  source_session_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'closed')),
+  active_revision INTEGER NOT NULL CHECK (active_revision >= 1),
+  rephrase_pending INTEGER NOT NULL DEFAULT 0 CHECK (rephrase_pending IN (0, 1)),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  CHECK (state = 'active' OR rephrase_pending = 0)
+) STRICT;
+
+CREATE UNIQUE INDEX explanations_one_active_per_source
+  ON explanations(source_session_id) WHERE state = 'active';
+CREATE UNIQUE INDEX explanations_one_active_per_topic
+  ON explanations(topic_id) WHERE state = 'active';
+
+CREATE TABLE entries (
+  entry_id TEXT PRIMARY KEY,
+  ordinal INTEGER NOT NULL UNIQUE CHECK (ordinal >= 1),
+  kind TEXT NOT NULL CHECK (kind IN ('explanation', 'feedback', 'topic-reopen')),
+  explanation_id TEXT REFERENCES explanations(explanation_id),
+  topic_id TEXT NOT NULL REFERENCES topics(topic_id),
+  revision INTEGER,
+  source_session_id TEXT,
+  source_turn INTEGER,
+  payload_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  CHECK (
+    (kind = 'explanation' AND explanation_id IS NOT NULL AND revision IS NOT NULL
+      AND source_session_id IS NOT NULL AND source_turn IS NOT NULL)
+    OR (kind = 'feedback' AND explanation_id IS NOT NULL AND revision IS NOT NULL
+      AND source_session_id IS NOT NULL AND source_turn IS NULL)
+    OR (kind = 'topic-reopen' AND explanation_id IS NULL AND revision IS NULL
+      AND source_session_id IS NULL AND source_turn IS NULL)
+  )
+) STRICT;
+
+CREATE INDEX entries_page ON entries(ordinal DESC);
+CREATE INDEX entries_explanation_revision ON entries(explanation_id, revision, ordinal);
+
+CREATE TABLE mutation_requests (
+  request_id TEXT PRIMARY KEY,
+  fingerprint TEXT NOT NULL,
+  entry_id TEXT NOT NULL REFERENCES entries(entry_id),
+  created_at INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE context_observations (
+  observation_id TEXT PRIMARY KEY,
+  source_session_id TEXT NOT NULL,
+  source_turn INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  confidence TEXT NOT NULL CHECK (confidence IN ('low', 'medium', 'high')),
+  created_at INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE context_checkpoints (
+  checkpoint_id TEXT PRIMARY KEY,
+  generation INTEGER NOT NULL UNIQUE CHECK (generation >= 1),
+  trigger TEXT NOT NULL CHECK (trigger IN ('idle', 'pressure')),
+  through_ordinal INTEGER NOT NULL CHECK (through_ordinal >= 0),
+  context_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  request_id TEXT NOT NULL UNIQUE
+) STRICT;
+
+CREATE TABLE context_coverage (
+  checkpoint_id TEXT NOT NULL REFERENCES context_checkpoints(checkpoint_id),
+  explanation_id TEXT NOT NULL UNIQUE REFERENCES explanations(explanation_id),
+  PRIMARY KEY (checkpoint_id, explanation_id)
+) WITHOUT ROWID, STRICT;
+
+CREATE TABLE observation_coverage (
+  checkpoint_id TEXT NOT NULL REFERENCES context_checkpoints(checkpoint_id),
+  observation_id TEXT NOT NULL UNIQUE REFERENCES context_observations(observation_id),
+  PRIMARY KEY (checkpoint_id, observation_id)
+) WITHOUT ROWID, STRICT;
+
+CREATE TABLE auto_request_usage (
+  auto_request_id TEXT PRIMARY KEY,
+  source_session_id TEXT NOT NULL,
+  started_at INTEGER NOT NULL
+) STRICT;
+
+CREATE INDEX auto_request_usage_window ON auto_request_usage(started_at);
+
+CREATE TABLE runtime_lease (
+  name TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  generation INTEGER NOT NULL CHECK (generation >= 1),
+  expires_at INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO meta(singleton, schema_version, store_revision, next_ordinal)
+VALUES (1, ${SCHEMA_VERSION}, 0, 1);
+INSERT INTO runtime_state(singleton, activity_generation, context_generation)
+VALUES (1, 0, 0);
+`

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,750 @@
+import { chmodSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { DatabaseSync } from 'node:sqlite'
+import { SessionId, type SessionId as SessionIdType } from '@deepseek-ai/dsh-session'
+import { EntryId, ExplanationId, ObservationId, RequestId, TopicId } from './brands.ts'
+import type {
+  DialoguePreferenceView,
+  ExplainContextStats,
+  ExplainContextView,
+  ExplainMutationFailure,
+  FeedbackMutationResult,
+  FeedbackRequest,
+  ReopenTopicRequest,
+  ReopenTopicResult,
+  ThreadEntryView,
+  ThreadPageRequest,
+  ThreadPageResult,
+  ViewCursor,
+  WatchResult,
+} from './types.ts'
+import { CREATE_SCHEMA_SQL, SCHEMA_VERSION } from './schema.ts'
+
+const DAY_MS = 24 * 60 * 60 * 1_000
+const DEFAULT_PAGE_LIMIT = 30
+const MAX_PAGE_LIMIT = 100
+const WATCH_TIMEOUT_MS = 25_000
+
+interface MetaRow {
+  schema_version: number
+  store_revision: number
+  next_ordinal: number
+}
+
+interface CountRow {
+  count: number
+}
+
+interface EntryRow {
+  entry_id: string
+  ordinal: number
+  kind: 'explanation' | 'feedback' | 'topic-reopen'
+  explanation_id: string | null
+  explanation_state: 'active' | 'closed' | null
+  topic_id: string
+  topic_key: string
+  topic_title: string
+  topic_state: 'learning' | 'mastered'
+  topic_revision: number
+  revision: number | null
+  source_session_id: string | null
+  source_turn: number | null
+  payload_json: string
+  created_at: number
+}
+
+interface ExplanationTargetRow {
+  explanation_id: string
+  source_session_id: string
+  state: 'active' | 'closed'
+  active_revision: number
+  rephrase_pending: 0 | 1
+  topic_id: string
+  topic_state: 'learning' | 'mastered'
+}
+
+interface TopicTargetRow {
+  topic_id: string
+  state: 'learning' | 'mastered'
+  topic_revision: number
+}
+
+interface CheckpointRow {
+  context_json: string
+  created_at: number
+}
+
+interface CheckpointPayload {
+  dialogueProfile?: unknown
+  knowledgeOverview?: unknown
+  learningTrend?: unknown
+}
+
+interface RequestReplayRow {
+  fingerprint: string
+  entry_id: string
+}
+
+/** Fixture-only input used by store and Remote integration tests. */
+export interface FixtureExplanationInput {
+  readonly topicKey: string
+  readonly title: string
+  readonly sourceSessionId: SessionIdType
+  readonly sourceTurn: number
+  readonly state?: 'active' | 'closed'
+  readonly topicState?: 'learning' | 'mastered'
+  readonly revisions?: readonly {
+    readonly title: string
+    readonly what: string
+    readonly why: string
+    readonly pitfall: string
+  }[]
+  readonly userText?: string
+  readonly toolNames?: readonly string[]
+  readonly cwdLabel?: string
+}
+
+/** One local SQLite learning thread and its process-local view notifications. */
+export class ExplainStore {
+  readonly incarnation = randomUUID()
+  private readonly database: DatabaseSync
+  private readonly listeners = new Set<() => void>()
+  private viewRevision = 0
+  private closed = false
+
+  /** Open or create one versioned learning database. */
+  constructor(readonly databasePath: string) {
+    const memory = databasePath === ':memory:'
+    if (!memory) {
+      const directory = dirname(databasePath)
+      mkdirSync(directory, { recursive: true, mode: 0o700 })
+      if (process.platform !== 'win32') chmodSync(directory, 0o700)
+    }
+    this.database = new DatabaseSync(databasePath)
+    try {
+      if (!memory && process.platform !== 'win32') chmodSync(databasePath, 0o600)
+      this.database.exec('PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000;')
+      if (!memory) this.database.exec('PRAGMA journal_mode = WAL;')
+      this.initialize()
+    } catch (error) {
+      this.database.close()
+      throw error
+    }
+  }
+
+  /** Current process-local cursor. */
+  cursor(): ViewCursor {
+    return { incarnation: this.incarnation, revision: this.viewRevision }
+  }
+
+  /** Current persistent store revision. */
+  storeRevision(): number {
+    return this.meta().store_revision
+  }
+
+  /** Count active explanations across every source Session. */
+  activeExplanationCount(): number {
+    return this.count('SELECT COUNT(*) AS count FROM explanations WHERE state = \'active\'')
+  }
+
+  /** Count autonomous requests sent in the rolling 24-hour window. */
+  autoRequestsUsed(now = Date.now()): number {
+    return this.count(
+      'SELECT COUNT(*) AS count FROM auto_request_usage WHERE started_at > ?',
+      now - DAY_MS,
+    )
+  }
+
+  /** Page backward through append-only entries without exposing sourceSummary. */
+  threadPage(request: ThreadPageRequest): ThreadPageResult {
+    const limit = request.limit ?? DEFAULT_PAGE_LIMIT
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_PAGE_LIMIT) {
+      throw new RangeError(`dsh-explain: page limit must be an integer from 1 to ${MAX_PAGE_LIMIT}`)
+    }
+    if (request.beforeOrdinal !== undefined
+      && (!Number.isInteger(request.beforeOrdinal) || request.beforeOrdinal < 1)) {
+      throw new RangeError('dsh-explain: beforeOrdinal must be a positive integer')
+    }
+    const rows = this.database.prepare(`
+      SELECT e.entry_id, e.ordinal, e.kind, e.explanation_id,
+             x.state AS explanation_state, e.topic_id,
+             t.topic_key, t.title AS topic_title, t.state AS topic_state,
+             t.topic_revision, e.revision, e.source_session_id, e.source_turn,
+             e.payload_json, e.created_at
+      FROM entries e
+      JOIN topics t ON t.topic_id = e.topic_id
+      LEFT JOIN explanations x ON x.explanation_id = e.explanation_id
+      WHERE (? IS NULL OR e.ordinal < ?)
+      ORDER BY e.ordinal DESC
+      LIMIT ?
+    `).all(request.beforeOrdinal ?? null, request.beforeOrdinal ?? null, limit + 1) as unknown as EntryRow[]
+    return {
+      entries: rows.slice(0, limit).map(row => this.entryView(row)),
+      hasMore: rows.length > limit,
+      storeRevision: this.storeRevision(),
+    }
+  }
+
+  /** Read the latest model checkpoint plus database-authoritative statistics. */
+  context(): ExplainContextView {
+    const stats = this.contextStats()
+    const checkpoint = this.database.prepare(`
+      SELECT context_json, created_at
+      FROM context_checkpoints
+      ORDER BY generation DESC
+      LIMIT 1
+    `).get() as unknown as CheckpointRow | undefined
+    if (checkpoint === undefined) {
+      return {
+        dialogueProfile: [],
+        knowledgeOverview: '',
+        learningTrend: '',
+        stats,
+        inferred: false,
+      }
+    }
+    const payload = parseObject(checkpoint.context_json, 'context checkpoint') as CheckpointPayload
+    const profile = parseDialogueProfile(payload.dialogueProfile)
+    return {
+      generatedAt: checkpoint.created_at,
+      dialogueProfile: profile,
+      knowledgeOverview: checkpointText(payload.knowledgeOverview, 'knowledgeOverview'),
+      learningTrend: checkpointText(payload.learningTrend, 'learningTrend'),
+      stats,
+      inferred: true,
+    }
+  }
+
+  /** Wait until the view cursor changes or the ordinary long-poll timeout elapses. */
+  async watch(after: ViewCursor, signal: AbortSignal): Promise<WatchResult> {
+    signal.throwIfAborted()
+    if (after.incarnation !== this.incarnation || after.revision !== this.viewRevision) {
+      return { cursor: this.cursor(), changed: true }
+    }
+    return await new Promise<WatchResult>((resolve, reject) => {
+      let settled = false
+      const finish = (result: WatchResult): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        signal.removeEventListener('abort', abort)
+        this.listeners.delete(changed)
+        resolve(result)
+      }
+      const changed = (): void => finish({ cursor: this.cursor(), changed: true })
+      const abort = (): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        this.listeners.delete(changed)
+        reject(signal.reason)
+      }
+      const timer = setTimeout(() => finish({ cursor: this.cursor(), changed: false }), WATCH_TIMEOUT_MS)
+      this.listeners.add(changed)
+      signal.addEventListener('abort', abort, { once: true })
+      if (after.revision !== this.viewRevision) changed()
+    })
+  }
+
+  /** Commit understood/not-understood feedback with request idempotency and Explanation revision CAS. */
+  feedback(request: FeedbackRequest): FeedbackMutationResult {
+    assertRequestId(request.requestId)
+    if (!Number.isInteger(request.revision) || request.revision < 1) {
+      throw new RangeError('dsh-explain: feedback revision must be a positive integer')
+    }
+    const result = this.write(() => {
+      const fingerprint = feedbackFingerprint(request)
+      const replay = this.requestReplay(request.requestId)
+      if (replay !== undefined) {
+        if (replay.fingerprint !== fingerprint) {
+          return failure('REQUEST_ID_CONFLICT', 'The request id already belongs to a different mutation.')
+        }
+        return {
+          ok: true as const,
+          value: {
+            entry: this.entryById(EntryId(replay.entry_id)),
+            storeRevision: this.storeRevision(),
+            rephrasePending: request.action === 'not-understood',
+          },
+        }
+      }
+      const target = this.database.prepare(`
+        SELECT e.explanation_id, e.source_session_id, e.state, e.active_revision, e.rephrase_pending,
+               e.topic_id, t.state AS topic_state
+        FROM explanations e
+        JOIN topics t ON t.topic_id = e.topic_id
+        WHERE e.explanation_id = ?
+      `).get(request.explanationId) as unknown as ExplanationTargetRow | undefined
+      if (target === undefined
+        || target.source_session_id !== request.sourceSessionId
+        || target.state !== 'active'
+        || target.active_revision !== request.revision) {
+        return failure('STALE_EXPLANATION_REVISION', 'The explanation revision is no longer active.')
+      }
+      if (target.rephrase_pending !== 0) {
+        if (request.action !== 'not-understood') {
+          return failure('STALE_EXPLANATION_REVISION', 'The explanation revision is awaiting a rephrase.')
+        }
+        const duplicate = this.database.prepare(`
+          SELECT e.entry_id
+          FROM entries e
+          WHERE e.explanation_id = ? AND e.revision = ? AND e.kind = 'feedback'
+            AND json_extract(e.payload_json, '$.action') = 'not-understood'
+          ORDER BY e.ordinal DESC LIMIT 1
+        `).get(request.explanationId, request.revision) as unknown as { entry_id: string } | undefined
+        if (duplicate === undefined) {
+          throw new Error('dsh-explain: rephrase-pending explanation has no not-understood entry')
+        }
+        this.recordRequest(request.requestId, fingerprint, EntryId(duplicate.entry_id))
+        return {
+          ok: true as const,
+          value: {
+            entry: this.entryById(EntryId(duplicate.entry_id)),
+            storeRevision: this.storeRevision(),
+            rephrasePending: true,
+          },
+        }
+      }
+      const entryId = EntryId(randomUUID())
+      const ordinal = this.takeOrdinal()
+      const now = Date.now()
+      this.database.prepare(`
+        INSERT INTO entries(
+          entry_id, ordinal, kind, explanation_id, topic_id, revision,
+          source_session_id, payload_json, created_at
+        ) VALUES (?, ?, 'feedback', ?, ?, ?, ?, ?, ?)
+      `).run(
+        entryId,
+        ordinal,
+        request.explanationId,
+        target.topic_id,
+        request.revision,
+        request.sourceSessionId,
+        JSON.stringify({ action: request.action }),
+        now,
+      )
+      this.recordRequest(request.requestId, fingerprint, entryId, now)
+      if (request.action === 'understood') {
+        this.database.prepare(`
+          UPDATE explanations SET state = 'closed', rephrase_pending = 0, updated_at = ?
+          WHERE explanation_id = ? AND state = 'active' AND active_revision = ?
+        `).run(now, request.explanationId, request.revision)
+        this.database.prepare(`
+          UPDATE topics SET state = 'mastered', topic_revision = topic_revision + 1, updated_at = ?
+          WHERE topic_id = ?
+        `).run(now, target.topic_id)
+        this.database.exec(`
+          UPDATE runtime_state
+          SET activity_generation = activity_generation + 1,
+              context_generation = context_generation + 1,
+              last_user_action_at = ${now}
+          WHERE singleton = 1
+        `)
+      } else {
+        this.database.prepare(`
+          UPDATE explanations SET rephrase_pending = 1, updated_at = ?
+          WHERE explanation_id = ? AND state = 'active' AND active_revision = ? AND rephrase_pending = 0
+        `).run(now, request.explanationId, request.revision)
+        this.database.exec(`
+          UPDATE runtime_state
+          SET activity_generation = activity_generation + 1,
+              last_user_action_at = ${now}
+          WHERE singleton = 1
+        `)
+      }
+      const storeRevision = this.advanceStoreRevision()
+      const entry = this.entryById(entryId)
+      return {
+        ok: true as const,
+        value: { entry, storeRevision, rephrasePending: request.action === 'not-understood' },
+      }
+    })
+    return result
+  }
+
+  /** Reopen a mastered Topic with Topic revision CAS. */
+  reopenTopic(request: ReopenTopicRequest): ReopenTopicResult {
+    assertRequestId(request.requestId)
+    if (!Number.isInteger(request.expectedTopicRevision) || request.expectedTopicRevision < 1) {
+      throw new RangeError('dsh-explain: expectedTopicRevision must be a positive integer')
+    }
+    return this.write(() => {
+      const fingerprint = reopenFingerprint(request)
+      const replay = this.requestReplay(request.requestId)
+      if (replay !== undefined) {
+        if (replay.fingerprint !== fingerprint) {
+          return failure('REQUEST_ID_CONFLICT', 'The request id already belongs to a different mutation.')
+        }
+        return {
+          ok: true as const,
+          value: { entry: this.entryById(EntryId(replay.entry_id)), storeRevision: this.storeRevision() },
+        }
+      }
+      const target = this.database.prepare(`
+        SELECT topic_id, state, topic_revision FROM topics WHERE topic_id = ?
+      `).get(request.topicId) as unknown as TopicTargetRow | undefined
+      if (target === undefined || target.topic_revision !== request.expectedTopicRevision) {
+        return failure('STALE_TOPIC_REVISION', 'The topic revision has changed.')
+      }
+      if (target.state !== 'mastered') {
+        return failure('TOPIC_NOT_MASTERED', 'Only a mastered topic can be reopened.')
+      }
+      const entryId = EntryId(randomUUID())
+      const ordinal = this.takeOrdinal()
+      const now = Date.now()
+      this.database.prepare(`
+        UPDATE topics SET state = 'learning', topic_revision = topic_revision + 1, updated_at = ?
+        WHERE topic_id = ? AND state = 'mastered' AND topic_revision = ?
+      `).run(now, request.topicId, request.expectedTopicRevision)
+      this.database.prepare(`
+        INSERT INTO entries(entry_id, ordinal, kind, topic_id, payload_json, created_at)
+        VALUES (?, ?, 'topic-reopen', ?, ?, ?)
+      `).run(entryId, ordinal, request.topicId, JSON.stringify({ action: 'reopen' }), now)
+      this.recordRequest(request.requestId, fingerprint, entryId, now)
+      this.database.exec(`
+        UPDATE runtime_state
+        SET activity_generation = activity_generation + 1,
+            last_user_action_at = ${now}
+        WHERE singleton = 1
+      `)
+      const storeRevision = this.advanceStoreRevision()
+      return { ok: true as const, value: { entry: this.entryById(entryId), storeRevision } }
+    })
+  }
+
+  /** Add deterministic-shape fixture data through the same schema used by production. Tests only. */
+  addFixtureExplanation(input: FixtureExplanationInput): ExplanationId {
+    return this.write(() => {
+      if (!/^[a-z0-9._/-]{1,80}$/.test(input.topicKey) || input.topicKey.split('/').some(part => part === '')) {
+        throw new Error('dsh-explain: fixture topicKey is invalid')
+      }
+      const revisions = input.revisions ?? [{
+        title: input.title,
+        what: `What ${input.title} means.`,
+        why: `Why ${input.title} matters.`,
+        pitfall: `A common ${input.title} pitfall.`,
+      }]
+      if (revisions.length === 0) throw new Error('dsh-explain: fixture requires one revision')
+      const topicId = TopicId(randomUUID())
+      const explanationId = ExplanationId(randomUUID())
+      const now = Date.now()
+      const latest = revisions.at(-1)!
+      this.database.prepare(`
+        INSERT INTO topics(topic_id, topic_key, title, state, topic_revision, updated_at)
+        VALUES (?, ?, ?, ?, 1, ?)
+      `).run(topicId, input.topicKey, latest.title, input.topicState ?? 'learning', now)
+      this.database.prepare(`
+        INSERT INTO explanations(
+          explanation_id, topic_id, source_session_id, state, active_revision, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        explanationId,
+        topicId,
+        input.sourceSessionId,
+        input.state ?? 'active',
+        revisions.length,
+        now,
+        now,
+      )
+      revisions.forEach((revision, index) => {
+        const ordinal = this.takeOrdinal()
+        const sourceSummary = index === 0 ? {
+          userText: (input.userText ?? `Learn ${input.title}`).slice(0, 2_000),
+          toolNames: [...new Set(input.toolNames ?? [])].slice(0, 32),
+          ...(input.cwdLabel === undefined ? {} : { cwdLabel: input.cwdLabel.slice(0, 160) }),
+          truncated: (input.userText?.length ?? 0) > 2_000 || (input.toolNames?.length ?? 0) > 32,
+        } : undefined
+        this.database.prepare(`
+          INSERT INTO entries(
+            entry_id, ordinal, kind, explanation_id, topic_id, revision,
+            source_session_id, source_turn, payload_json, created_at
+          ) VALUES (?, ?, 'explanation', ?, ?, ?, ?, ?, ?, ?)
+        `).run(
+          EntryId(randomUUID()),
+          ordinal,
+          explanationId,
+          topicId,
+          index + 1,
+          input.sourceSessionId,
+          input.sourceTurn,
+          JSON.stringify({ ...revision, ...(sourceSummary === undefined ? {} : { sourceSummary }) }),
+          now + index,
+        )
+      })
+      this.database.prepare(`
+        UPDATE runtime_state
+        SET first_explain_output_at = COALESCE(first_explain_output_at, ?),
+            context_generation = context_generation + 1
+        WHERE singleton = 1
+      `).run(now)
+      this.advanceStoreRevision()
+      return explanationId
+    })
+  }
+
+  /** Close the SQLite handle and reject future writes. */
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    for (const listener of [...this.listeners]) listener()
+    this.listeners.clear()
+    this.database.close()
+  }
+
+  private initialize(): void {
+    const row = this.database.prepare(`
+      SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'meta'
+    `).get()
+    if (row === undefined) {
+      this.database.exec('BEGIN IMMEDIATE')
+      try {
+        this.database.exec(CREATE_SCHEMA_SQL)
+        this.database.exec('COMMIT')
+      } catch (error) {
+        this.database.exec('ROLLBACK')
+        throw error
+      }
+      return
+    }
+    const meta = this.meta()
+    if (meta.schema_version !== SCHEMA_VERSION) {
+      throw new Error(`dsh-explain: unsupported schema version ${meta.schema_version}; expected ${SCHEMA_VERSION}`)
+    }
+    const foreignKeys = this.database.prepare('PRAGMA foreign_key_check').all()
+    if (foreignKeys.length > 0) throw new Error('dsh-explain: database foreign-key integrity check failed')
+  }
+
+  private meta(): MetaRow {
+    const row = this.database.prepare(`
+      SELECT schema_version, store_revision, next_ordinal FROM meta WHERE singleton = 1
+    `).get() as unknown as MetaRow | undefined
+    if (row === undefined) throw new Error('dsh-explain: database meta row is missing')
+    return row
+  }
+
+  private count(sql: string, ...parameters: (string | number | null)[]): number {
+    const row = this.database.prepare(sql).get(...parameters) as unknown as CountRow | undefined
+    if (row === undefined || !Number.isInteger(row.count) || row.count < 0) {
+      throw new Error('dsh-explain: invalid database count result')
+    }
+    return row.count
+  }
+
+  private contextStats(): ExplainContextStats {
+    return {
+      learningTopics: this.count('SELECT COUNT(*) AS count FROM topics WHERE state = \'learning\''),
+      masteredTopics: this.count('SELECT COUNT(*) AS count FROM topics WHERE state = \'mastered\''),
+      activeExplanations: this.activeExplanationCount(),
+      understoodFeedback: this.count(`
+        SELECT COUNT(*) AS count FROM entries
+        WHERE kind = 'feedback' AND json_extract(payload_json, '$.action') = 'understood'
+      `),
+      notUnderstoodFeedback: this.count(`
+        SELECT COUNT(*) AS count FROM entries
+        WHERE kind = 'feedback' AND json_extract(payload_json, '$.action') = 'not-understood'
+      `),
+    }
+  }
+
+  private takeOrdinal(): number {
+    const ordinal = this.meta().next_ordinal
+    this.database.prepare('UPDATE meta SET next_ordinal = next_ordinal + 1 WHERE singleton = 1').run()
+    return ordinal
+  }
+
+  private advanceStoreRevision(): number {
+    this.database.prepare('UPDATE meta SET store_revision = store_revision + 1 WHERE singleton = 1').run()
+    return this.storeRevision()
+  }
+
+  private write<T>(operation: () => T): T {
+    if (this.closed) throw new Error('dsh-explain: store is closed')
+    const startingRevision = this.storeRevision()
+    this.database.exec('BEGIN IMMEDIATE')
+    try {
+      const value = operation()
+      const changed = this.storeRevision() !== startingRevision
+      this.database.exec('COMMIT')
+      if (changed) {
+        this.viewRevision += 1
+        for (const listener of [...this.listeners]) listener()
+      }
+      return value
+    } catch (error) {
+      this.database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
+  private entryById(entryId: EntryId): ThreadEntryView {
+    const row = this.entryRow('e.entry_id = ?', entryId)
+    if (row === undefined) throw new Error(`dsh-explain: committed entry ${entryId} is missing`)
+    return this.entryView(row)
+  }
+
+  private requestReplay(requestId: RequestId): RequestReplayRow | undefined {
+    return this.database.prepare(`
+      SELECT fingerprint, entry_id FROM mutation_requests WHERE request_id = ?
+    `).get(requestId) as unknown as RequestReplayRow | undefined
+  }
+
+  private recordRequest(
+    requestId: RequestId,
+    fingerprint: string,
+    entryId: EntryId,
+    createdAt = Date.now(),
+  ): void {
+    this.database.prepare(`
+      INSERT INTO mutation_requests(request_id, fingerprint, entry_id, created_at)
+      VALUES (?, ?, ?, ?)
+    `).run(requestId, fingerprint, entryId, createdAt)
+  }
+
+  private entryRow(predicate: string, value: string): EntryRow | undefined {
+    return this.database.prepare(`
+      SELECT e.entry_id, e.ordinal, e.kind, e.explanation_id,
+             x.state AS explanation_state, e.topic_id,
+             t.topic_key, t.title AS topic_title, t.state AS topic_state,
+             t.topic_revision, e.revision, e.source_session_id, e.source_turn,
+             e.payload_json, e.created_at
+      FROM entries e
+      JOIN topics t ON t.topic_id = e.topic_id
+      LEFT JOIN explanations x ON x.explanation_id = e.explanation_id
+      WHERE ${predicate}
+      LIMIT 1
+    `).get(value) as unknown as EntryRow | undefined
+  }
+
+  private entryView(row: EntryRow): ThreadEntryView {
+    const payload = parseObject(row.payload_json, `entry ${row.entry_id}`)
+    let publicPayload: ThreadEntryView['payload']
+    if (row.kind === 'explanation') {
+      const { title, what, why, pitfall } = payload
+      if (![title, what, why, pitfall].every(value => typeof value === 'string')) {
+        throw new Error(`dsh-explain: explanation entry ${row.entry_id} has an invalid payload`)
+      }
+      publicPayload = { title: title as string, what: what as string, why: why as string, pitfall: pitfall as string }
+    } else if (row.kind === 'feedback') {
+      if (payload.action !== 'understood' && payload.action !== 'not-understood') {
+        throw new Error(`dsh-explain: feedback entry ${row.entry_id} has an invalid payload`)
+      }
+      publicPayload = { action: payload.action }
+    } else {
+      if (payload.action !== 'reopen') throw new Error(`dsh-explain: reopen entry ${row.entry_id} has an invalid payload`)
+      publicPayload = { action: 'reopen' }
+    }
+    return {
+      entryId: EntryId(row.entry_id),
+      ordinal: row.ordinal,
+      kind: row.kind,
+      ...(row.explanation_id === null ? {} : { explanationId: ExplanationId(row.explanation_id) }),
+      ...(row.explanation_state === null ? {} : { explanationState: row.explanation_state }),
+      topicId: TopicId(row.topic_id),
+      topicKey: row.topic_key,
+      topicTitle: row.topic_title,
+      topicState: row.topic_state,
+      topicRevision: row.topic_revision,
+      ...(row.revision === null ? {} : { revision: row.revision }),
+      ...(row.source_session_id === null ? {} : { sourceSessionId: SessionId(row.source_session_id) }),
+      ...(row.source_turn === null ? {} : { sourceTurn: row.source_turn }),
+      payload: publicPayload,
+      createdAt: row.created_at,
+    }
+  }
+}
+
+function parseDialogueProfile(value: unknown): readonly DialoguePreferenceView[] {
+  if (!Array.isArray(value) || value.length > 16) {
+    throw new Error('dsh-explain: context checkpoint dialogueProfile must contain at most 16 items')
+  }
+  return value.map((candidate, index) => {
+    if (candidate === null || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      throw new Error(`dsh-explain: dialogueProfile item ${index + 1} must be an object`)
+    }
+    const item = candidate as Record<string, unknown>
+    const keys = Object.keys(item).sort()
+    const expectedKeys = [
+      'confidence',
+      'evidenceEntryOrdinals',
+      'evidenceObservationIds',
+      'kind',
+      'preference',
+    ]
+    if (keys.length !== expectedKeys.length || keys.some((key, keyIndex) => key !== expectedKeys[keyIndex])) {
+      throw new Error(`dsh-explain: dialogueProfile item ${index + 1} has unexpected fields`)
+    }
+    if (item.kind !== 'verbosity' && item.kind !== 'structure'
+      && item.kind !== 'examples' && item.kind !== 'terminology') {
+      throw new Error(`dsh-explain: dialogueProfile item ${index + 1} has an invalid kind`)
+    }
+    if (item.confidence !== 'low' && item.confidence !== 'medium' && item.confidence !== 'high') {
+      throw new Error(`dsh-explain: dialogueProfile item ${index + 1} has invalid confidence`)
+    }
+    if (typeof item.preference !== 'string' || item.preference.length === 0 || item.preference.length > 240) {
+      throw new Error(`dsh-explain: dialogueProfile item ${index + 1} has an invalid preference`)
+    }
+    if (!Array.isArray(item.evidenceObservationIds) || item.evidenceObservationIds.length > 8
+      || item.evidenceObservationIds.some(identity => typeof identity !== 'string' || identity.length === 0)) {
+      throw new Error(`dsh-explain: dialogueProfile item ${index + 1} has invalid observation evidence`)
+    }
+    if (!Array.isArray(item.evidenceEntryOrdinals) || item.evidenceEntryOrdinals.length > 8
+      || item.evidenceEntryOrdinals.some(ordinal => !Number.isInteger(ordinal) || (ordinal as number) < 1)) {
+      throw new Error(`dsh-explain: dialogueProfile item ${index + 1} has invalid entry evidence`)
+    }
+    return {
+      kind: item.kind,
+      preference: item.preference,
+      confidence: item.confidence,
+      evidenceObservationIds: item.evidenceObservationIds.map(identity => ObservationId(identity as string)),
+      evidenceEntryOrdinals: item.evidenceEntryOrdinals as number[],
+    }
+  })
+}
+
+function checkpointText(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length > 2_000) {
+    throw new Error(`dsh-explain: context checkpoint ${field} must be a string of at most 2,000 characters`)
+  }
+  return value
+}
+
+function feedbackFingerprint(request: FeedbackRequest): string {
+  return JSON.stringify([
+    'feedback',
+    request.sourceSessionId,
+    request.explanationId,
+    request.revision,
+    request.action,
+  ])
+}
+
+function reopenFingerprint(request: ReopenTopicRequest): string {
+  return JSON.stringify(['topic-reopen', request.topicId, request.expectedTopicRevision])
+}
+
+function parseObject(value: string, label: string): Record<string, unknown> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch (error) {
+    throw new Error(`dsh-explain: ${label} contains invalid JSON`, { cause: error })
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`dsh-explain: ${label} must contain a JSON object`)
+  }
+  return parsed as Record<string, unknown>
+}
+
+function assertRequestId(requestId: RequestId): void {
+  if (typeof requestId !== 'string' || requestId.length === 0 || requestId.length > 160) {
+    throw new Error('dsh-explain: requestId must be a non-empty string of at most 160 characters')
+  }
+}
+
+function failure(
+  code: ExplainMutationFailure['code'],
+  message: string,
+): { readonly ok: false; readonly error: ExplainMutationFailure } {
+  return { ok: false, error: { code, message } }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,159 @@
+import type { SessionId } from '@deepseek-ai/dsh-session'
+import type { EntryId, ExplanationId, ObservationId, RequestId, TopicId } from './brands.ts'
+
+export type { EntryId, ExplanationId, ObservationId, RequestId, TopicId } from './brands.ts'
+
+/** Monotonic process-local cursor used by long-polling clients. */
+export interface ViewCursor {
+  readonly incarnation: string
+  readonly revision: number
+}
+
+/** Public plugin runtime state. */
+export type ExplainRuntimeState = 'disabled' | 'ready' | 'failed'
+
+/** Read-only status returned to every learning view. */
+export interface ExplainStatusView {
+  readonly enabled: boolean
+  readonly runtimeState: ExplainRuntimeState
+  readonly activeExplanationCount: number
+  readonly pendingCandidateCount: number
+  readonly autoRequestsUsed: number
+  readonly autoRequestsLimit: number
+  readonly storeRevision: number
+  readonly cursor: ViewCursor
+}
+
+/** Sanitized explanation payload visible to the browser. */
+export interface ExplanationPayloadView {
+  readonly title: string
+  readonly what: string
+  readonly why: string
+  readonly pitfall: string
+}
+
+/** Sanitized feedback payload visible to the browser. */
+export interface FeedbackPayloadView {
+  readonly action: 'understood' | 'not-understood'
+}
+
+/** Sanitized Topic reopen payload visible to the browser. */
+export interface ReopenPayloadView {
+  readonly action: 'reopen'
+}
+
+/** One append-only learning entry; private sourceSummary data is never projected here. */
+export interface ThreadEntryView {
+  readonly entryId: EntryId
+  readonly ordinal: number
+  readonly kind: 'explanation' | 'feedback' | 'topic-reopen'
+  readonly explanationId?: ExplanationId
+  readonly explanationState?: 'active' | 'closed'
+  readonly topicId: TopicId
+  readonly topicKey: string
+  readonly topicTitle: string
+  readonly topicState: 'learning' | 'mastered'
+  readonly topicRevision: number
+  readonly revision?: number
+  readonly sourceSessionId?: SessionId
+  readonly sourceTurn?: number
+  readonly payload: ExplanationPayloadView | FeedbackPayloadView | ReopenPayloadView
+  readonly createdAt: number
+}
+
+/** Backward page request over immutable ordinals. */
+export interface ThreadPageRequest {
+  readonly beforeOrdinal?: number
+  readonly limit?: number
+}
+
+/** One immutable learning-thread page. */
+export interface ThreadPageResult {
+  readonly entries: readonly ThreadEntryView[]
+  readonly hasMore: boolean
+  readonly storeRevision: number
+}
+
+/** Database-authoritative learning statistics. */
+export interface ExplainContextStats {
+  readonly learningTopics: number
+  readonly masteredTopics: number
+  readonly activeExplanations: number
+  readonly understoodFeedback: number
+  readonly notUnderstoodFeedback: number
+}
+
+/** One evidence-backed explanation-style preference inferred by the auxiliary model. */
+export interface DialoguePreferenceView {
+  readonly kind: 'verbosity' | 'structure' | 'examples' | 'terminology'
+  readonly preference: string
+  readonly confidence: 'low' | 'medium' | 'high'
+  readonly evidenceObservationIds: readonly ObservationId[]
+  readonly evidenceEntryOrdinals: readonly number[]
+}
+
+/** Read-only ExplainContext projection. Model-generated fields are absent before M2 creates a checkpoint. */
+export interface ExplainContextView {
+  readonly generatedAt?: number
+  readonly dialogueProfile: readonly DialoguePreferenceView[]
+  readonly knowledgeOverview: string
+  readonly learningTrend: string
+  readonly stats: ExplainContextStats
+  readonly inferred: boolean
+}
+
+/** Long-poll request from one previously observed view cursor. */
+export interface WatchRequest {
+  readonly after: ViewCursor
+}
+
+/** Long-poll result; changed=false is the ordinary timeout case. */
+export interface WatchResult {
+  readonly cursor: ViewCursor
+  readonly changed: boolean
+}
+
+/** Entity-scoped feedback mutation. */
+export interface FeedbackRequest {
+  readonly requestId: RequestId
+  readonly sourceSessionId: SessionId
+  readonly explanationId: ExplanationId
+  readonly revision: number
+  readonly action: 'understood' | 'not-understood'
+}
+
+/** Entity-scoped Topic reopen mutation. */
+export interface ReopenTopicRequest {
+  readonly requestId: RequestId
+  readonly topicId: TopicId
+  readonly expectedTopicRevision: number
+}
+
+/** Stable business failure returned across the typed Remote. */
+export interface ExplainMutationFailure {
+  readonly code: 'EXPLAIN_DISABLED' | 'REQUEST_ID_CONFLICT' | 'STALE_EXPLANATION_REVISION' | 'STALE_TOPIC_REVISION' | 'TOPIC_NOT_MASTERED'
+  readonly message: string
+}
+
+/** Accepted feedback state. */
+export interface FeedbackMutationValue {
+  readonly entry: ThreadEntryView
+  readonly storeRevision: number
+  readonly rephrasePending: boolean
+}
+
+/** Accepted Topic reopen state. */
+export interface ReopenTopicValue {
+  readonly entry: ThreadEntryView
+  readonly storeRevision: number
+}
+
+/** Feedback mutation result with business failures kept out of transport errors. */
+export type FeedbackMutationResult =
+  | { readonly ok: true; readonly value: FeedbackMutationValue }
+  | { readonly ok: false; readonly error: ExplainMutationFailure }
+
+/** Topic reopen result with business failures kept out of transport errors. */
+export type ReopenTopicResult =
+  | { readonly ok: true; readonly value: ReopenTopicValue }
+  | { readonly ok: false; readonly error: ExplainMutationFailure }

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveExplainConfig } from '../src/config.ts'
+
+const directories: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+function directory(): string {
+  const value = mkdtempSync(join(tmpdir(), 'dsh-explain-config-'))
+  directories.push(value)
+  return value
+}
+
+describe('resolveExplainConfig', () => {
+  it('resolves defaults beneath the active DSH home', () => {
+    const dshHome = directory()
+    vi.stubEnv('DSH_HOME', dshHome)
+    const config = resolveExplainConfig({})
+    expect(config).toMatchObject({
+      enabled: false,
+      maxPendingCandidates: 8,
+      maxAutoRequestsPerDay: 50,
+      idleCompactMs: 1_800_000,
+      contextThresholdRatio: 0.5,
+      dshHome,
+      storageDir: join(dshHome, 'dsh-explain', 'v1'),
+      databasePath: join(dshHome, 'dsh-explain', 'v1', 'thread.sqlite'),
+    })
+    expect(config).not.toHaveProperty('provider')
+    expect(config).not.toHaveProperty('model')
+  })
+
+  it('normalizes model routing and resolves a relative plugin storage directory', () => {
+    const dshHome = directory()
+    expect(resolveExplainConfig({
+      dshHome,
+      storageDir: 'private/explain',
+      provider: '  deepseek-official  ',
+      model: '  deepseek-chat  ',
+    })).toMatchObject({
+      provider: 'deepseek-official',
+      model: 'deepseek-chat',
+      storageDir: join(dshHome, 'private', 'explain'),
+      databasePath: join(dshHome, 'private', 'explain', 'thread.sqlite'),
+    })
+  })
+
+  it('preserves an explicit absolute storage directory', () => {
+    const storageDir = directory()
+    expect(resolveExplainConfig({ dshHome: directory(), storageDir }).databasePath)
+      .toBe(join(storageDir, 'thread.sqlite'))
+  })
+
+  it('rejects unknown configuration fields before opening storage', () => {
+    expect(() => resolveExplainConfig({ surprise: true } as never)).toThrow('unknown config key "surprise"')
+    expect(() => resolveExplainConfig(null as never)).toThrow('configuration must be a plain object')
+  })
+})

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import { remoteMethods } from '@deepseek-ai/dsh-type-meta'
+import { Config, apply, inject, name } from '../src/index.ts'
+
+const directories: string[] = []
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+describe('dsh-explain plugin lifecycle', () => {
+  it('publishes the exact Remote namespace and closes its database with the fiber', async () => {
+    const dshHome = mkdtempSync(join(tmpdir(), 'dsh-explain-plugin-'))
+    directories.push(dshHome)
+    const ctx = new Context()
+    const fiber = ctx.plugin({ name, Config, inject, apply }, { dshHome })
+    await fiber.await()
+    try {
+      expect(ctx.explain.typertGateway).toMatchObject({ serviceKey: 'explain', namespace: 'explain' })
+      expect(remoteMethods(ctx.explain)).toEqual([
+        { method: 'status', invocation: { kind: 'direct' } },
+        { method: 'threadPage', invocation: { kind: 'direct' } },
+        { method: 'context', invocation: { kind: 'direct' } },
+        { method: 'watch', invocation: { kind: 'direct' } },
+        { method: 'feedback', invocation: { kind: 'direct' } },
+        { method: 'reopenTopic', invocation: { kind: 'direct' } },
+      ])
+      expect(ctx.explain.status()).toMatchObject({
+        enabled: false,
+        runtimeState: 'disabled',
+        activeExplanationCount: 0,
+        storeRevision: 0,
+      })
+    } finally {
+      await fiber.dispose()
+    }
+    rmSync(dshHome, { recursive: true, force: true })
+    directories.splice(directories.indexOf(dshHome), 1)
+  })
+})

--- a/tests/store.spec.ts
+++ b/tests/store.spec.ts
@@ -1,0 +1,336 @@
+import {
+  chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SessionId } from '@deepseek-ai/dsh-session'
+import { RequestId } from '../src/brands.ts'
+import { ExplainStore } from '../src/store.ts'
+
+const stores: ExplainStore[] = []
+const directories: string[] = []
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close()
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+function memoryStore(): ExplainStore {
+  const store = new ExplainStore(':memory:')
+  stores.push(store)
+  return store
+}
+
+function diskPath(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'dsh-explain-test-'))
+  directories.push(directory)
+  return join(directory, 'nested', 'thread.sqlite')
+}
+
+function fixture(store: ExplainStore, source = 'session-a', topic = 'typescript/narrowing') {
+  const explanationId = store.addFixtureExplanation({
+    topicKey: topic,
+    title: 'Narrowing',
+    sourceSessionId: SessionId(source),
+    sourceTurn: 7,
+    revisions: [
+      { title: 'Narrowing basics', what: 'First what', why: 'First why', pitfall: 'First pitfall' },
+      { title: 'Narrowing precisely', what: 'Latest what', why: 'Latest why', pitfall: 'Latest pitfall' },
+    ],
+    userText: `private-source-${source}`,
+    toolNames: ['bash', 'bash', 'read'],
+    cwdLabel: 'workspace',
+  })
+  const page = store.threadPage({ limit: 10 })
+  const latest = page.entries.find(entry => entry.explanationId === explanationId && entry.revision === 2)
+  if (latest === undefined) throw new Error('fixture explanation is missing')
+  return { explanationId, latest }
+}
+
+describe('ExplainStore schema and projections', () => {
+  it.skipIf(process.platform === 'win32')('repairs private permissions and preserves state across restart', () => {
+    const path = diskPath()
+    mkdirSync(join(path, '..'), { recursive: true, mode: 0o755 })
+    chmodSync(join(path, '..'), 0o755)
+    const first = new ExplainStore(path)
+    stores.push(first)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+    expect(statSync(join(path, '..')).mode & 0o077).toBe(0)
+    const { explanationId } = fixture(first)
+    for (const file of readdirSync(join(path, '..'))) {
+      expect(statSync(join(path, '..', file)).mode & 0o077).toBe(0)
+    }
+    expect(first.storeRevision()).toBe(1)
+    first.close()
+    stores.splice(stores.indexOf(first), 1)
+
+    const reopened = new ExplainStore(path)
+    stores.push(reopened)
+    expect(reopened.storeRevision()).toBe(1)
+    expect(reopened.activeExplanationCount()).toBe(1)
+    expect(reopened.threadPage({}).entries.some(entry => entry.explanationId === explanationId)).toBe(true)
+  })
+
+  it('pages newest first while stripping the private source summary', () => {
+    const store = memoryStore()
+    fixture(store)
+    const newest = store.threadPage({ limit: 1 })
+    expect(newest.entries).toHaveLength(1)
+    expect(newest.hasMore).toBe(true)
+    expect(newest.entries[0]?.ordinal).toBe(2)
+    expect(JSON.stringify(newest.entries)).not.toContain('private-source')
+    expect(JSON.stringify(newest.entries)).not.toContain('sourceSummary')
+
+    const beforeOrdinal = newest.entries[0]?.ordinal
+    if (beforeOrdinal === undefined) throw new Error('newest fixture page is empty')
+    const older = store.threadPage({ beforeOrdinal, limit: 1 })
+    expect(older.entries[0]?.ordinal).toBe(1)
+    expect(older.entries[0]?.payload).toEqual({
+      title: 'Narrowing basics',
+      what: 'First what',
+      why: 'First why',
+      pitfall: 'First pitfall',
+    })
+    expect(older.entries[0]?.topicTitle).toBe('Narrowing precisely')
+  })
+
+  it('enforces one active explanation per source without retaining a partial write', () => {
+    const store = memoryStore()
+    fixture(store)
+    expect(() => fixture(store, 'session-a', 'typescript/generics')).toThrow(/UNIQUE constraint failed/)
+    expect(store.storeRevision()).toBe(1)
+    expect(store.context().stats).toMatchObject({ learningTopics: 1, activeExplanations: 1 })
+  })
+
+  it('rejects an unknown schema without replacing the original database', () => {
+    const path = diskPath()
+    const store = new ExplainStore(path)
+    store.close()
+    const database = new DatabaseSync(path)
+    database.exec('UPDATE meta SET schema_version = 99 WHERE singleton = 1')
+    database.close()
+
+    expect(() => new ExplainStore(path)).toThrow('unsupported schema version 99')
+    const verify = new DatabaseSync(path)
+    expect((verify.prepare('SELECT schema_version FROM meta').get() as { schema_version: number }).schema_version).toBe(99)
+    verify.close()
+  })
+
+  it('reports corrupt SQLite input instead of silently reinitializing it', () => {
+    const path = diskPath()
+    const seed = new ExplainStore(path)
+    seed.close()
+    writeFileSync(path, 'this is not sqlite')
+    const before = readFileSync(path)
+    expect(() => new ExplainStore(path)).toThrow()
+    expect(readFileSync(path)).toEqual(before)
+  })
+
+  it('validates page requests at the Remote boundary', () => {
+    const store = memoryStore()
+    expect(() => store.threadPage({ limit: 0 })).toThrow(RangeError)
+    expect(() => store.threadPage({ limit: 101 })).toThrow(RangeError)
+    expect(() => store.threadPage({ beforeOrdinal: 0 })).toThrow(RangeError)
+  })
+})
+
+describe('ExplainStore feedback and entity CAS', () => {
+  it('keeps stale failures and exact idempotent replays revision-neutral', () => {
+    const store = memoryStore()
+    const { explanationId, latest } = fixture(store)
+    const cursor = store.cursor()
+    const stale = store.feedback({
+      requestId: RequestId('stale'),
+      sourceSessionId: SessionId('session-a'),
+      explanationId,
+      revision: 1,
+      action: 'understood',
+    })
+    expect(stale).toMatchObject({ ok: false, error: { code: 'STALE_EXPLANATION_REVISION' } })
+    expect(store.cursor()).toEqual(cursor)
+    expect(store.storeRevision()).toBe(1)
+
+    const request = {
+      requestId: RequestId('retry-me'),
+      sourceSessionId: SessionId('session-a'),
+      explanationId,
+      revision: latest.revision!,
+      action: 'not-understood' as const,
+    }
+    const accepted = store.feedback(request)
+    expect(accepted).toMatchObject({ ok: true, value: { rephrasePending: true } })
+    const acceptedCursor = store.cursor()
+    const acceptedRevision = store.storeRevision()
+    expect(store.feedback(request)).toEqual(accepted)
+    expect(store.cursor()).toEqual(acceptedCursor)
+    expect(store.storeRevision()).toBe(acceptedRevision)
+
+    const semanticDuplicate = store.feedback({ ...request, requestId: RequestId('same-meaning') })
+    expect(semanticDuplicate).toMatchObject({
+      ok: true,
+      value: { entry: { entryId: accepted.ok && accepted.value.entry.entryId }, rephrasePending: true },
+    })
+    expect(store.cursor()).toEqual(acceptedCursor)
+    expect(store.storeRevision()).toBe(acceptedRevision)
+    expect(store.feedback({ ...request, requestId: RequestId('same-meaning') })).toEqual(semanticDuplicate)
+  })
+
+  it('rejects RequestId reuse for a different mutation', () => {
+    const store = memoryStore()
+    const { explanationId, latest } = fixture(store)
+    const requestId = RequestId('one-operation-only')
+    const first = store.feedback({
+      requestId,
+      sourceSessionId: SessionId('session-a'),
+      explanationId,
+      revision: latest.revision!,
+      action: 'not-understood',
+    })
+    expect(first.ok).toBe(true)
+    const cursor = store.cursor()
+    expect(store.feedback({
+      requestId,
+      sourceSessionId: SessionId('session-a'),
+      explanationId,
+      revision: latest.revision!,
+      action: 'understood',
+    })).toMatchObject({ ok: false, error: { code: 'REQUEST_ID_CONFLICT' } })
+    expect(store.reopenTopic({
+      requestId,
+      topicId: latest.topicId,
+      expectedTopicRevision: latest.topicRevision,
+    })).toMatchObject({ ok: false, error: { code: 'REQUEST_ID_CONFLICT' } })
+    expect(store.cursor()).toEqual(cursor)
+  })
+
+  it('recovers a pending rephrase and its idempotency aliases after restart', () => {
+    const path = diskPath()
+    const first = new ExplainStore(path)
+    const { explanationId, latest } = fixture(first)
+    const initial = first.feedback({
+      requestId: RequestId('durable-rephrase'),
+      sourceSessionId: SessionId('session-a'),
+      explanationId,
+      revision: latest.revision!,
+      action: 'not-understood',
+    })
+    expect(initial.ok).toBe(true)
+    first.close()
+
+    const reopened = new ExplainStore(path)
+    stores.push(reopened)
+    const aliasRequest = {
+      requestId: RequestId('durable-rephrase-alias'),
+      sourceSessionId: SessionId('session-a'),
+      explanationId,
+      revision: latest.revision!,
+      action: 'not-understood' as const,
+    }
+    const alias = reopened.feedback(aliasRequest)
+    expect(alias).toMatchObject({ ok: true, value: { rephrasePending: true } })
+    expect(reopened.feedback(aliasRequest)).toEqual(alias)
+    expect(reopened.feedback({
+      ...aliasRequest,
+      requestId: RequestId('cannot-master-pending'),
+      action: 'understood',
+    })).toMatchObject({ ok: false, error: { code: 'STALE_EXPLANATION_REVISION' } })
+  })
+
+  it('masters only the addressed explanation, then reopens its Topic with Topic CAS', () => {
+    const store = memoryStore()
+    const left = fixture(store, 'session-a', 'typescript/narrowing')
+    const right = fixture(store, 'session-b', 'sqlite/wal')
+    const understood = store.feedback({
+      requestId: RequestId('understood-left'),
+      sourceSessionId: SessionId('session-a'),
+      explanationId: left.explanationId,
+      revision: left.latest.revision!,
+      action: 'understood',
+    })
+    expect(understood).toMatchObject({
+      ok: true,
+      value: { entry: { topicState: 'mastered', topicRevision: 2 }, rephrasePending: false },
+    })
+    expect(store.activeExplanationCount()).toBe(1)
+    expect(store.threadPage({ limit: 20 }).entries.find(entry => entry.explanationId === right.explanationId)?.topicState)
+      .toBe('learning')
+
+    const stale = store.reopenTopic({
+      requestId: RequestId('stale-topic'),
+      topicId: left.latest.topicId,
+      expectedTopicRevision: 1,
+    })
+    expect(stale).toMatchObject({ ok: false, error: { code: 'STALE_TOPIC_REVISION' } })
+    const reopened = store.reopenTopic({
+      requestId: RequestId('reopen-left'),
+      topicId: left.latest.topicId,
+      expectedTopicRevision: 2,
+    })
+    expect(reopened).toMatchObject({ ok: true, value: { entry: { topicState: 'learning', topicRevision: 3 } } })
+    if (!reopened.ok) throw new Error('Topic did not reopen')
+    const revision = store.storeRevision()
+    const cursor = store.cursor()
+    expect(store.reopenTopic({
+      requestId: RequestId('reopen-left'),
+      topicId: left.latest.topicId,
+      expectedTopicRevision: 2,
+    })).toEqual(reopened)
+    expect(store.reopenTopic({
+      requestId: RequestId('reopen-left'),
+      topicId: left.latest.topicId,
+      expectedTopicRevision: 3,
+    })).toMatchObject({ ok: false, error: { code: 'REQUEST_ID_CONFLICT' } })
+    expect(store.storeRevision()).toBe(revision)
+    expect(store.cursor()).toEqual(cursor)
+  })
+
+  it('lets only one of two tabs commit the same Explanation revision', () => {
+    const store = memoryStore()
+    const { explanationId, latest } = fixture(store)
+    const base = {
+      sourceSessionId: SessionId('session-a'),
+      explanationId,
+      revision: latest.revision!,
+      action: 'understood' as const,
+    }
+    expect(store.feedback({ ...base, requestId: RequestId('tab-one') }).ok).toBe(true)
+    expect(store.feedback({ ...base, requestId: RequestId('tab-two') }))
+      .toMatchObject({ ok: false, error: { code: 'STALE_EXPLANATION_REVISION' } })
+  })
+})
+
+describe('ExplainStore long polling', () => {
+  it('wakes on a committed store revision and not on a stale failure', async () => {
+    const store = memoryStore()
+    const controller = new AbortController()
+    const waiting = store.watch(store.cursor(), controller.signal)
+    fixture(store)
+    await expect(waiting).resolves.toMatchObject({ changed: true, cursor: { revision: 1 } })
+
+    const current = store.cursor()
+    const abort = new AbortController()
+    const unchanged = store.watch(current, abort.signal)
+    const page = store.threadPage({ limit: 1 })
+    const latest = page.entries[0]!
+    store.feedback({
+      requestId: RequestId('stale-watch'),
+      sourceSessionId: SessionId('session-a'),
+      explanationId: latest.explanationId!,
+      revision: 1,
+      action: 'understood',
+    })
+    expect(store.cursor()).toEqual(current)
+    abort.abort()
+    await expect(unchanged).rejects.toThrow()
+  })
+
+  it('releases outstanding watchers during close', async () => {
+    const store = memoryStore()
+    const waiting = store.watch(store.cursor(), new AbortController().signal)
+    store.close()
+    stores.splice(stores.indexOf(store), 1)
+    await expect(waiting).resolves.toMatchObject({ changed: true })
+  })
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "useDefineForClassFields": true
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.host.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "types": [],
+    "rootDir": "src/client",
+    "outDir": "lib/client",
+    "allowImportingTsExtensions": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true
+  },
+  "include": ["src/client"]
+}

--- a/tsconfig.host.json
+++ b/tsconfig.host.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib/types",
+    "composite": true,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/client"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.host.json" },
+    { "path": "./tsconfig.client.json" }
+  ]
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["tests"]
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['lib/types/index.js'],
+  outDir: 'lib',
+  format: ['esm'],
+  platform: 'node',
+  target: 'es2024',
+  fixedExtension: false,
+  dts: false,
+  clean: false,
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.spec.ts', 'tests/**/*.spec.tsx'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- scaffold a private standalone DSH bundle with deterministic local DSH source linking
- add the v1 SQLite global learning store with schema checks, private permissions, paging, watch, CAS, and durable idempotency
- generate and mount strict TypeRT Host/Client Remote contracts for status, thread, context, watch, feedback, and topic reopening

## Scope

M1 is intentionally non-visual: it does not observe turns, call a model, or register the Learning view. Those capabilities land together in M2 so GUI acceptance can exercise the real model flow instead of fixtures.

## Design review fixes

- persist rephrase-pending state and mutation request fingerprints
- make coverage tables the sole coverage source
- reject RequestId reuse with different payloads and keep source summaries out of client projections
- initialize the client bundle CommonJS envelope and fail the build when it is missing

## Checks

- clean offline frozen-lockfile install
- local DSH source link setup
- pnpm run test (18 passed)
- pnpm run typecheck
- pnpm run build
- isolated local profile composed with dsh-explain as the final layer
- real DSH Web boot: Host and client loaded, main UI rendered, browser console clean
- SQLite database, WAL, and shared-memory files verified mode 0600