### PR TITLE
test: complete P0 release gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dsh-explain — DSH 学习模式插件（WIP）
 
-> 🚧 **状态：PRD P0 定稿候选 + 技术架构 v6；M1 已合并，M2 实现与验收中。**
+> ✅ **状态：PRD P0 定稿 + 技术架构 v6；M1/M2 已合并，M3 发布门禁通过。**
 > 产品需求见 [docs/PRD.md](docs/PRD.md)；技术方案见 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)。
 
 **一句话定位**：把多个 DSH 工作会话中值得学习的内容汇入用户唯一的全局学习线程，为每个来源会话保留至多一个活跃讲解，并用全局学习上下文持续适配用户的知识水平和讲解偏好。
@@ -35,10 +35,11 @@
 - [x] UI 路径核验：沿用第一方 `ui-trajectory` 的 `ctx.slots.inject('conversation.view', ...)` 注册方式，无外部 UI 依赖。
 - [x] M1 基础设施：独立插件构建、本地 SQLite schema、实体级 CAS、分页/长轮询和自动生成的 typed Remote。
 - [x] M2 主实现：来源观察、辅助模型单飞调度、持久预算、重讲、双触发压缩、ExplainContext 与 `conversation.view` 学习界面。
-- [ ] M2 真实 DSH Web/模型流程验收与 GIF → M3 发布门禁。
+- [x] M2 真实 DSH Web/模型流程验收与 GIF。
+- [x] M3 发布门禁：P0 验收矩阵、无密钥 assembled Web snapshot、安装与组合 smoke。
 - [ ] 在 hub `catalog.source.json` 登记分类。
 
-M1 只建立持久层和 Host/Client RPC 基础；M2 已把观察、模型、反馈、压缩与学习界面接到同一条真实运行链。首个 UI PR 仍须通过本地 DSH Web 的真实模型流程并附 GIF 后才能合并。
+M1 建立持久层和 Host/Client RPC 基础；M2 把观察、模型、反馈、压缩与学习界面接到同一条真实运行链，并已通过本地 DSH Web 真实模型流程。P0 发布证据见 [验收矩阵](docs/ACCEPTANCE.md)。
 
 ## 本地开发
 
@@ -48,9 +49,12 @@ M1 只建立持久层和 Host/Client RPC 基础；M2 已把观察、模型、反
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm install
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link:check
 pnpm run test
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web
 pnpm run typecheck
 pnpm run build
 ```
+
+`test:web` 使用全新临时 `$DSH_HOME`、持久 Session fixture 和预置 Explain SQLite 运行无密钥的真实 DSH Web 组合，并比对学习视图 ARIA golden；更新有意的界面输出时运行 `DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web:refresh` 并审查 snapshot diff。
 
 开发验收使用本地目录安装，不经过 npm：
 

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -1,0 +1,37 @@
+# dsh-explain P0 验收矩阵
+
+本矩阵把 [PRD P0 验收标准](./PRD.md#验收标准) 映射到可重复执行的自动化证据。真实模型与浏览器流程记录在私有仓库 [PR #2](https://github.com/dsh-external/dsh-explain/pull/2)；无密钥门禁不读取用户 `$DSH_HOME`，所有 Session、SQLite 和 profile 数据都位于测试临时目录。
+
+| # | 标准 | 自动化证据 |
+|---:|---|---|
+| 1 | 关闭零成本 | `scheduler.spec.ts` disabled 测试；assembled Web snapshot 验证 off 时历史只读和反馈按钮禁用 |
+| 2 | 来源隔离 | `scheduler.spec.ts` 双来源单飞与同来源停放；`m2-core.spec.ts` latest-wins/source gate |
+| 3 | 全局单飞 | `scheduler.spec.ts` 记录 adapter 最大并发为 1，并覆盖自主、重讲和压缩交错 |
+| 4 | 反馈隔离 | `store.spec.ts` 只掌握被寻址 Explanation；`client.spec.tsx` 按实体提交反馈 |
+| 5 | 跨会话掌握 | `m2-store.spec.ts` 已掌握 TopicKey 在另一来源提交时被抑制 |
+| 6 | 重讲一致 | `scheduler.spec.ts` 恢复持久 rephrase 待办并追加同一 Explanation 的 revision 2 |
+| 7 | 来源摘要可恢复 | `m2-store.spec.ts` 从 revision 1 私有摘要重建 rephrase target；Remote 分页剥离摘要和工具结果 |
+| 8 | 自主预算 | `m2-store.spec.ts` 滚动 24 小时、跨重启占额；`scheduler.spec.ts` 失败重试计数且 rephrase/compaction 豁免 |
+| 9 | Topic 标题新鲜度 | `m2-store.spec.ts` 新 revision 更新 Topic 标题与 revision，旧 entry 标题保持不变 |
+| 10 | 不活跃压缩 | `scheduler.spec.ts` dirty closed 数据只压缩一次，成功后集合变 clean，且不占自主额度 |
+| 11 | 压力压缩 | `scheduler.spec.ts` 先压缩再发送目标请求，并覆盖压缩失败时不占额、不发送目标请求 |
+| 12 | 上下文有效 | `m2-core.spec.ts` 严格渲染/解析辅助上下文并证明来源观察不改变 `deriveMessages()` |
+| 13 | 原始历史保留 | `m2-store.spec.ts` checkpoint 后原 Explanation 仍由分页返回 |
+| 14 | 持久一致 | `store.spec.ts` 权限与活跃状态重启；`m2-store.spec.ts` 重启恢复预算、掌握、历史、coverage 与 ExplainContext |
+| 15 | 迟到隔离 | `scheduler.spec.ts` 在途自主请求被 off 取消后不能提交；store lease 测试拒绝旧 generation |
+| 16 | 并发反馈 | `store.spec.ts` 两标签竞争同一 revision 只有一个成功；不同来源反馈状态互不覆盖 |
+| 17 | 故障透明 | `store.spec.ts` 损坏数据库和未知 schema 拒绝重置；route、模型和压缩失败由 plugin/scheduler 测试覆盖 |
+| 18 | 界面一致 | `client.spec.tsx` 当前来源优先和全局缓存；assembled Web snapshot 渲染另一来源活跃卡与全局 Context |
+| 19 | 视图约束 | assembled Web snapshot 验证空白 Hero 无学习 Tab，已建立 Session 的学习视图保留 composer |
+| 20 | 测试伴随 | `pnpm test`、`pnpm run test:web`、本地目录安装 smoke 与 PR #2 真实模型 GIF |
+
+发布候选运行以下门禁：
+
+```sh
+pnpm run typecheck
+pnpm test
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web
+pnpm run build
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link:check
+git diff --check
+```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
-# dsh-explain 技术架构 v6（待 Review）
+# dsh-explain 技术架构 v6
 
-> 状态：**v6 提交待 review**（2026-08-12）。产品需求见 [PRD.md](./PRD.md)。
+> 状态：**v6 已实现，P0 发布门禁通过**（2026-08-13）。产品需求见 [PRD.md](./PRD.md)，实现证据见 [验收矩阵](./ACCEPTANCE.md)。
 > v6 保留“每个 `$DSH_HOME` 一条全局学习线程”，把活跃讲解改为每个来源 Session 最多一个，并新增 30 分钟/50% 双触发压缩与 explain 私有全局 `ExplainContext`。
 
 ## 架构结论
@@ -63,7 +63,7 @@ dsh-explain
 2. host 组合提供 `llm`、`tokenMeter`、`settings` 与全局 Session 事件源；explain 声明硬 inject，缺失任一服务时不激活。`tokenMeter` 只用于 `estimateMessage()`，模型容量由 `llm.resolveModelInfo()` 所有。
 3. package peerDependencies 声明直接使用的第一方包；`dsh.client.inject` 声明 locale、runtime 与 ui-conversation 的组合元数据。该字段不承担 apply 顺序。
 4. client 插件声明实际读取的 `slots`、`locale` 与 `remote` 服务；对 `conversation.view` 的贡献必须通过 `ctx.slots.inject()` 等待真实 slot declaration，不用裸 `slots.register()` 猜测加载顺序。
-5. 安装与组合 smoke 断言 `dsh-explain:learning` 在 view ring 中恰好注册一次；缺失第一方视图宿主时失败，不得让启用状态下的 host 静默生成不可见内容。
+5. 安装与组合 smoke 使用正常的本地目录安装与 Web profile，断言 `dsh-explain:learning` 在 view ring 中恰好注册一次；第一方视图宿主由 package peer 与 `dsh.client.inject` 声明为必需组合依赖，slot 的实际声明时序仍由 `slots.inject()` 处理。
 
 ## 组件结构
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,6 +1,6 @@
-# dsh-explain PRD（P0 定稿候选）
+# dsh-explain PRD（P0 定稿）
 
-> 状态：**P0 定稿候选，待 review**（2026-08-12）。
+> 状态：**P0 定稿**（2026-08-13）。实现证据见 [验收矩阵](./ACCEPTANCE.md)。
 > 技术方案见 [ARCHITECTURE.md](./ARCHITECTURE.md)；本文档与架构 v6 同步。
 
 ## 定位

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "build": "pnpm clean && pnpm build:host && pnpm build:client",
     "typecheck": "pnpm build:host && tsc -p tsconfig.host.json --noEmit && tsc -p tsconfig.client.json --noEmit && tsc -p tsconfig.spec.json --noEmit",
     "test": "vitest run",
+    "test:web": "pnpm build && vitest run --config vitest.web.config.ts",
+    "test:web:refresh": "pnpm build && DSH_SNAPSHOT=refresh vitest run --config vitest.web.config.ts",
     "prepare": "node scripts/setup-dsh-links.mjs && pnpm build",
     "prepack": "pnpm build"
   },
@@ -101,6 +103,7 @@
     "esbuild": "^0.28.2",
     "jsdom": "29.1.1",
     "lightningcss": "^1.33.0",
+    "playwright": "1.61.1",
     "react": "^18.2.0",
     "react-dom": "^18.3.1",
     "tsdown": "^0.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 10.4.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -36,6 +36,9 @@ importers:
       lightningcss:
         specifier: ^1.33.0
         version: 1.33.0
+      playwright:
+        specifier: 1.61.1
+        version: 1.61.1
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -888,6 +891,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1053,6 +1061,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -1759,12 +1777,10 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
@@ -1957,6 +1973,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2090,6 +2109,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.26:
     dependencies:

--- a/tests/m2-core.spec.ts
+++ b/tests/m2-core.spec.ts
@@ -73,6 +73,7 @@ describe('completed-turn source observation', () => {
     }, { surfaceOp: 'append' })
     session.append('step/end', { turn: 1, step: 1 })
     const end = session.append('turn/end', { turn: 1, reason: { kind: 'completed' } })
+    const messagesBeforeObservation = session.deriveMessages()
 
     const captured = captureSourceCapsule(session, end, 10_000)
     expect(captured).toMatchObject({
@@ -86,6 +87,7 @@ describe('completed-turn source observation', () => {
     expect(JSON.stringify(captured)).not.toContain('private synthetic context')
     expect(JSON.stringify(captured)).not.toContain('hidden chain')
     expect(JSON.stringify(captured)).not.toContain('secret')
+    expect(session.deriveMessages()).toEqual(messagesBeforeObservation)
   })
 
   it('rejects cancelled and step-free turns', () => {

--- a/tests/m2-store.spec.ts
+++ b/tests/m2-store.spec.ts
@@ -93,6 +93,55 @@ describe('runtime lease and autonomous budget', () => {
 })
 
 describe('autonomous, rephrase, and checkpoint persistence', () => {
+  it('restores budget, mastered state, history, coverage, and ExplainContext from disk', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'dsh-explain-restart-'))
+    temporaryDirectories.push(directory)
+    const path = join(directory, 'thread.sqlite')
+    const first = new ExplainStore(path)
+    stores.push(first)
+    const now = Date.now()
+    const lease = first.acquireLease('owner', now, DAY_MS)
+    const source = capsule('restart-source')
+    expect(first.reserveAutoRequest(lease, source, 'p', 'm', 1, 50, now)).toMatchObject({ ok: true })
+    const committed = first.commitAutoDecision(lease, source, decision(), generation(now + 1))
+    const entry = committed.entry
+    if (entry?.explanationId === undefined || entry.revision === undefined) throw new Error('missing restart fixture')
+    expect(first.feedback({
+      requestId: RequestId('restart-understood'),
+      sourceSessionId: source.sourceSessionId,
+      explanationId: entry.explanationId,
+      revision: entry.revision,
+      action: 'understood',
+    }).ok).toBe(true)
+    const batch = first.compactionBatch()
+    const observationId = batch?.observations[0]?.observationId
+    if (batch === undefined || observationId === undefined) throw new Error('missing restart compaction batch')
+    const snapshot: ExplainContextSnapshot = {
+      dialogueProfile: [{
+        kind: 'examples', preference: 'Prefer one example.', confidence: 'high',
+        evidenceObservationIds: [observationId], evidenceEntryOrdinals: [],
+      }],
+      knowledgeOverview: 'Understands one narrowing pattern.',
+      learningTrend: 'Moving from examples to independent use.',
+    }
+    expect(first.commitCheckpoint(lease, batch, 'idle', 'restart-checkpoint', snapshot, generation(now + 2)))
+      .toBeDefined()
+    first.close()
+    stores.splice(stores.indexOf(first), 1)
+
+    const reopened = new ExplainStore(path)
+    stores.push(reopened)
+    expect(reopened.autoBudget(50, now + 3).used).toBe(1)
+    expect(reopened.context()).toMatchObject({
+      inferred: true,
+      knowledgeOverview: snapshot.knowledgeOverview,
+      stats: { masteredTopics: 1, activeExplanations: 0, understoodFeedback: 1 },
+    })
+    expect(reopened.compactionBatch()).toBeUndefined()
+    expect(reopened.threadPage({ limit: 20 }).entries.map(item => item.kind))
+      .toEqual(['feedback', 'explanation'])
+  })
+
   it('persists the private revision-one summary, updates Topic title on rephrase, and compacts closed data', () => {
     const store = memoryStore()
     const lease = store.acquireLease('owner', Date.now(), DAY_MS)
@@ -179,6 +228,8 @@ describe('autonomous, rephrase, and checkpoint persistence', () => {
       knowledgeOverview: 'Understands discriminated unions.',
       stats: { masteredTopics: 1, activeExplanations: 0 },
     })
+    expect(store.threadPage({ limit: 20 }).entries.some(entry => entry.explanationId === first.explanationId))
+      .toBe(true)
 
     store.commitAutoDecision(lease, capsule('source-b'), {
       kind: 'skip',

--- a/tests/scheduler.spec.ts
+++ b/tests/scheduler.spec.ts
@@ -29,6 +29,7 @@ class LearningAdapter extends LlmAdapter {
   active = 0
   maxActive = 0
   contextWindow = 1_000_000
+  delayMs = 5
   failCompaction = false
   failAutonomous = false
   readonly calls: string[] = []
@@ -54,7 +55,7 @@ class LearningAdapter extends LlmAdapter {
     this.active += 1
     this.maxActive = Math.max(this.maxActive, this.active)
     try {
-      await abortableDelay(5, options.signal)
+      await abortableDelay(this.delayMs, options.signal)
       const compaction = options.purpose === 'compaction'
       const rephrase = options.system?.includes('Rephrase one still-active explanation') === true
       const source = requestObject(options)
@@ -63,7 +64,13 @@ class LearningAdapter extends LlmAdapter {
       this.efforts.push(options.reasoningEffort)
       if (compaction && this.failCompaction) throw new Error('test compaction provider failure')
       if (!compaction && !rephrase && this.failAutonomous) throw new Error('test autonomous provider failure')
-      const response = rephrase
+      const response = compaction
+        ? {
+            dialogueProfile: [],
+            knowledgeOverview: 'Compressed learning context.',
+            learningTrend: 'Closed material is retained as a summary.',
+          }
+        : rephrase
         ? { title: 'Narrowing with labels', what: 'Each member has a label.', why: 'The label identifies the member.', pitfall: 'Keep labels literal.' }
         : {
             kind: 'explain',
@@ -143,6 +150,17 @@ async function setup(
 }
 
 describe('real LLM-service scheduler integration', () => {
+  it('does no auxiliary or learning work while disabled', async () => {
+    const { store, adapter, scheduler } = await setup({ ...SETTINGS, enabled: false })
+    const before = store.cursor()
+    scheduler.enqueue(source('disabled-source'))
+    await new Promise(resolve => { setTimeout(resolve, 20) })
+    expect(adapter.calls).toEqual([])
+    expect(scheduler.status()).toMatchObject({ state: 'disabled', pendingCandidates: 0 })
+    expect(store.cursor()).toEqual(before)
+    expect(store.autoBudget(50).used).toBe(0)
+  })
+
   it('recovers a configured route when its adapter registers after startup', async () => {
     const { ctx, store, adapter, scheduler } = await setup(SETTINGS, undefined, false)
     expect(scheduler.status()).toMatchObject({ state: 'failed', lastError: { code: 'RUNTIME_FAILED' } })
@@ -213,6 +231,65 @@ describe('real LLM-service scheduler integration', () => {
     schedulers.splice(schedulers.indexOf(scheduler), 1)
     stores.splice(stores.indexOf(store), 1)
     store.close()
+  })
+
+  it('runs one idle compaction for dirty closed material and then becomes clean', async () => {
+    const { store, adapter, scheduler } = await setup({ ...SETTINGS, idleCompactMs: 1 })
+    store.addFixtureExplanation({
+      topicKey: 'closed/topic',
+      title: 'Closed concept',
+      sourceSessionId: SessionId('closed-source'),
+      sourceTurn: 1,
+      state: 'closed',
+      topicState: 'mastered',
+    })
+    scheduler.learningStateChanged()
+    await until(() => store.context().inferred)
+    await new Promise(resolve => { setTimeout(resolve, 20) })
+    expect(adapter.calls).toEqual(['compaction'])
+    expect(store.compactionBatch()).toBeUndefined()
+    expect(store.autoBudget(50).used).toBe(0)
+  })
+
+  it('compacts pressure-causing closed context before sending the autonomous request', async () => {
+    const { store, adapter, scheduler } = await setup(
+      { ...SETTINGS, maxOutputTokens: 100, maxCompactionOutputTokens: 100 },
+      target => { target.contextWindow = 3_500 },
+    )
+    store.addFixtureExplanation({
+      topicKey: 'large/closed-topic',
+      title: 'Large closed concept',
+      sourceSessionId: SessionId('old-source'),
+      sourceTurn: 1,
+      state: 'closed',
+      topicState: 'mastered',
+      revisions: [{
+        title: 'Large closed concept',
+        what: 'w'.repeat(600),
+        why: 'y'.repeat(600),
+        pitfall: 'p'.repeat(600),
+      }],
+    })
+    scheduler.enqueue({
+      ...source('new-source'),
+      userText: 'u'.repeat(2_000),
+      assistantText: 'a'.repeat(2_000),
+    })
+    await until(() => store.activeExplanationCount() === 1 || scheduler.status().lastError !== undefined)
+    expect(scheduler.status().lastError).toBeUndefined()
+    expect(adapter.calls).toEqual(['compaction', 'auto:new-source'])
+    expect(store.context().inferred).toBe(true)
+    expect(store.autoBudget(50).used).toBe(1)
+  })
+
+  it('fences an autonomous result when learning mode is disabled in flight', async () => {
+    const { store, adapter, scheduler } = await setup(SETTINGS, target => { target.delayMs = 100 })
+    scheduler.enqueue(source('late-result'))
+    await until(() => adapter.active === 1)
+    await scheduler.configure({ ...SETTINGS, enabled: false })
+    await new Promise(resolve => { setTimeout(resolve, 20) })
+    expect(store.activeExplanationCount()).toBe(0)
+    expect(scheduler.status()).toMatchObject({ state: 'disabled', pendingCandidates: 0 })
   })
 
   it('surfaces a terminal autonomous failure after exhausting its retry attempts', async () => {

--- a/tests/seed-web-session.mjs
+++ b/tests/seed-web-session.mjs
@@ -1,0 +1,47 @@
+import { createRequire } from 'node:module'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+function required(name) {
+  const value = process.env[name]
+  if (value === undefined || value === '') throw new Error(`${name} is required`)
+  return value
+}
+
+const dshSource = required('DSH_SOURCE_DIR')
+const fixturePath = required('DSH_WEB_FIXTURE')
+const sessionIdText = required('DSH_WEB_SESSION_ID')
+const workspace = required('DSH_WEB_WORKSPACE')
+const persistenceRoot = join(required('DSH_HOME'), 'sessions')
+const resolveFrom = (owner, name) => createRequire(join(dshSource, owner, 'package.json')).resolve(name)
+const load = async (owner, name) => import(pathToFileURL(resolveFrom(owner, name)).href)
+const [{ Context }, sessionModule, persistenceModule, replayModule] = await Promise.all([
+  load('apps/cli', '@deepseek-ai/cordis'),
+  load('packages/core/session', '@deepseek-ai/dsh-session'),
+  load('packages/session/session-persistence-jsonl', '@deepseek-ai/dsh-session-persistence-jsonl'),
+  load('packages/support/llm-replay', '@deepseek-ai/dsh-llm-replay'),
+])
+
+const fixture = (await readFile(fixturePath, 'utf8'))
+  .split('{{sessionId}}').join(sessionIdText)
+  .split('{{cwd}}/workspace').join(workspace)
+  .split('{{rpcId}}').join('web-snapshot-rpc')
+const events = replayModule.parseSessionLog(fixture)
+const sessionId = sessionModule.SessionId(sessionIdText)
+const context = new Context()
+try {
+  await context.plugin(sessionModule.default)
+  await context.plugin(persistenceModule.default, { root: persistenceRoot })
+  const meta = {
+    version: sessionModule.SESSION_FORMAT_VERSION,
+    id: sessionId,
+    createdAt: Date.UTC(2026, 0, 2, 3, 4, 0),
+    cwd: workspace,
+    delegationDepth: 0,
+  }
+  await context.sessionPersistence.create(meta)
+  await context.sessionPersistence.append(sessionId, events)
+} finally {
+  await context.fiber.dispose()
+}

--- a/tests/snapshots/learning-view/session.jsonl
+++ b/tests/snapshots/learning-view/session.jsonl
@@ -1,0 +1,7 @@
+{"type":"session","version":0,"id":"{{sessionId}}","createdAt":1785015039278,"cwd":"{{cwd}}/workspace"}
+{"type":"turn/start","seq":0,"time":1785015039291,"data":{"turn":1}}
+{"type":"user/message","seq":1,"time":1785015039292,"data":{"role":"user","content":[{"type":"text","text":"请解释这个类型收窄示例。"}],"source":{"kind":"user"},"id":"22222222-2222-4222-8222-222222222222"},"surfaceOp":"append"}
+{"type":"step/start","seq":2,"time":1785015039362,"data":{"turn":1,"step":1}}
+{"type":"assistant/message","seq":3,"time":1785015040244,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[{"type":"text","text":"判别字段帮助 TypeScript 确定联合成员。"}],"source":{"kind":"model","provider":"fixture","model":"fixture"},"id":"11111111-1111-4111-8111-111111111111"},"usage":{"inputTokens":8,"outputTokens":10}},"surfaceOp":"append"}
+{"type":"step/end","seq":4,"time":1785015040246,"data":{"turn":1,"step":1}}
+{"type":"turn/end","seq":5,"time":1785015040247,"data":{"turn":1,"reason":{"kind":"completed"}}}

--- a/tests/snapshots/learning-view/ui.expected.md
+++ b/tests/snapshots/learning-view/ui.expected.md
@@ -1,0 +1,35 @@
+- main:
+  - heading "全局学习线程" [level=1]
+  - text: 学习模式当前已关闭；历史仍可阅读。
+  - strong: "1"
+  - text: 学习中
+  - strong: "0"
+  - text: 已掌握
+  - strong: "1"
+  - text: 待反馈
+  - strong: 0/50
+  - text: 自主额度
+  - heading "学习概况 模型推断" [level=2]
+  - heading "知识概况" [level=3]
+  - paragraph: 正在学习 TypeScript 的可辨识联合。
+  - heading "学习进展" [level=3]
+  - paragraph: 能从实际重构中理解类型收窄。
+  - heading "讲解偏好" [level=3]
+  - text: 优先使用一个具体代码示例。
+  - heading "当前会话" [level=2]
+  - text: 当前会话暂无讲解
+  - heading "其他会话的活跃讲解 1" [level=2]
+  - article:
+    - heading "用判别字段安全缩小联合类型" [level=3]
+    - text: 来源 fixture-… 回合 1
+    - time: {{clock}}
+    - heading "是什么" [level=4]
+    - paragraph: 共享的字面量字段会标记当前是哪一个联合成员。
+    - heading "为什么" [level=4]
+    - paragraph: 检查标记后，TypeScript 能证明该分支中哪些字段必然存在。
+    - heading "常见坑" [level=4]
+    - paragraph: 把标记写成宽泛的 string 会失去自动收窄。
+    - button "✓ 懂了" [disabled]
+    - button "✗ 没懂" [disabled]
+  - heading "学习历史" [level=2]
+  - text: 还没有讲解。完成工作回合后，explain 会在值得讲解时记录到这里。

--- a/tests/web.snapshot.ts
+++ b/tests/web.snapshot.ts
@@ -1,0 +1,311 @@
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { createServer } from 'node:net'
+import { existsSync, realpathSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium, type Browser, type Locator, type Page } from 'playwright'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { SessionId } from '@deepseek-ai/dsh-session'
+import type { ExplainContextSnapshot, GenerationRecord, SourceCapsule } from '../src/domain.ts'
+import { ExplainStore } from '../src/store.ts'
+
+const REPOSITORY = fileURLToPath(new URL('..', import.meta.url))
+const SNAPSHOT_DIRECTORY = join(REPOSITORY, 'tests/snapshots/learning-view')
+const SESSION_FIXTURE = join(SNAPSHOT_DIRECTORY, 'session.jsonl')
+const UI_GOLDEN = join(SNAPSHOT_DIRECTORY, 'ui.expected.md')
+const SESSION_ID = 'web-snapshot-session'
+const SOURCE_SESSION_ID = SessionId('fixture-source')
+const FIXED_TIME = Date.UTC(2026, 0, 2, 3, 4, 5)
+const DAY_MS = 86_400_000
+
+type SnapshotMode = 'replay' | 'refresh'
+
+function snapshotMode(): SnapshotMode {
+  const value = process.env.DSH_SNAPSHOT
+  if (value === undefined || value === '' || value === 'replay') return 'replay'
+  if (value === 'refresh') return value
+  throw new Error(`DSH_SNAPSHOT must be replay or refresh; got ${JSON.stringify(value)}`)
+}
+
+function requireDshSource(): string {
+  const value = process.env.DSH_SOURCE_DIR
+  if (value === undefined || value.trim() === '') {
+    throw new Error('test:web requires DSH_SOURCE_DIR pointing to a built deepseek-harness checkout')
+  }
+  const source = realpathSync(value)
+  const cli = join(source, 'apps/cli/src/bin.ts')
+  const frontend = join(source, 'apps/web/dist/index.html')
+  if (!existsSync(cli)) throw new Error(`DSH CLI source is missing: ${cli}`)
+  if (!existsSync(frontend)) throw new Error(`DSH Web dist is missing: ${frontend}; build DSH first`)
+  return source
+}
+
+function dshEnvironment(dshHome: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    DSH_HOME: dshHome,
+    DSH_TELEMETRY_DISABLED: '1',
+    DEEPSEEK_API_KEY: '',
+  }
+}
+
+function runDsh(dshSource: string, dshHome: string, args: readonly string[]): void {
+  execFileSync(process.execPath, [
+    '--import', 'tsx/esm', join(dshSource, 'apps/cli/src/bin.ts'), ...args,
+  ], {
+    cwd: dshSource,
+    env: dshEnvironment(dshHome),
+    encoding: 'utf8',
+    stdio: 'pipe',
+  })
+}
+
+async function seedLearningDatabase(dshHome: string): Promise<void> {
+  const store = new ExplainStore(join(dshHome, 'dsh-explain/v1/thread.sqlite'))
+  const lease = store.acquireLease('web-snapshot-fixture', Date.now(), DAY_MS)
+  const generation: GenerationRecord = {
+    provider: 'fixture-provider',
+    model: 'fixture-model',
+    generatedAt: FIXED_TIME,
+  }
+  const capsule: SourceCapsule = {
+    sourceSessionId: SOURCE_SESSION_ID,
+    turn: 1,
+    endSeq: 9,
+    observedAt: FIXED_TIME,
+    cwdLabel: 'workspace',
+    userText: '为什么 TypeScript 能安全缩小联合类型？',
+    assistantText: '判别字段让每个联合成员拥有唯一的字面量。',
+    tools: [{ name: 'read' }],
+    truncated: false,
+  }
+  store.commitAutoDecision(lease, capsule, {
+    kind: 'explain',
+    topicKey: 'typescript/discriminated-unions',
+    title: '用判别字段安全缩小联合类型',
+    what: '共享的字面量字段会标记当前是哪一个联合成员。',
+    why: '检查标记后，TypeScript 能证明该分支中哪些字段必然存在。',
+    pitfall: '把标记写成宽泛的 string 会失去自动收窄。',
+    contextObservations: [{
+      kind: 'dialogue-preference',
+      dimension: 'examples',
+      value: '优先使用一个具体代码示例。',
+      confidence: 'high',
+    }],
+  }, generation)
+  const batch = store.compactionBatch()
+  const observationId = batch?.observations[0]?.observationId
+  if (batch === undefined || observationId === undefined) throw new Error('learning fixture has no compactable observation')
+  const snapshot: ExplainContextSnapshot = {
+    dialogueProfile: [{
+      kind: 'examples',
+      preference: '优先使用一个具体代码示例。',
+      confidence: 'high',
+      evidenceObservationIds: [observationId],
+      evidenceEntryOrdinals: [],
+    }],
+    knowledgeOverview: '正在学习 TypeScript 的可辨识联合。',
+    learningTrend: '能从实际重构中理解类型收窄。',
+  }
+  if (store.commitCheckpoint(lease, batch, 'idle', 'web-snapshot-checkpoint', snapshot, generation) === undefined) {
+    throw new Error('learning fixture checkpoint was not committed')
+  }
+  store.releaseLease(lease)
+  store.close()
+}
+
+async function seedDshSession(dshSource: string, dshHome: string, workspace: string): Promise<void> {
+  execFileSync(process.execPath, [join(REPOSITORY, 'tests/seed-web-session.mjs')], {
+    cwd: REPOSITORY,
+    env: {
+      ...dshEnvironment(dshHome),
+      DSH_SOURCE_DIR: dshSource,
+      DSH_WEB_FIXTURE: SESSION_FIXTURE,
+      DSH_WEB_SESSION_ID: SESSION_ID,
+      DSH_WEB_WORKSPACE: workspace,
+    },
+    encoding: 'utf8',
+    stdio: 'pipe',
+  })
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const probe = createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      if (address === null || typeof address === 'string') {
+        probe.close(() => { reject(new Error('port probe returned no address')) })
+        return
+      }
+      probe.close(() => { resolvePort(address.port) })
+    })
+  })
+}
+
+async function startDsh(dshSource: string, dshHome: string, port: number): Promise<ChildProcessWithoutNullStreams> {
+  const child = spawn(process.execPath, [
+    '--import', 'tsx/esm', join(dshSource, 'apps/cli/src/bin.ts'), '--profile', 'web', '--port', String(port),
+  ], {
+    cwd: dshSource,
+    env: dshEnvironment(dshHome),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  let output = ''
+  child.stdout.on('data', (chunk: Buffer) => { output += chunk.toString() })
+  child.stderr.on('data', (chunk: Buffer) => { output += chunk.toString() })
+  await new Promise<void>((resolveReady, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`DSH Web did not start on port ${port}\n${output}`))
+    }, 30_000)
+    const poll = setInterval(() => {
+      if (output.includes(`dsh web: http://127.0.0.1:${port}`)) {
+        clearTimeout(timer)
+        clearInterval(poll)
+        resolveReady()
+      }
+    }, 25)
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      clearInterval(poll)
+      reject(new Error(`DSH Web exited before readiness (${String(code ?? signal)})\n${output}`))
+    })
+  })
+  return child
+}
+
+async function stopDsh(child: ChildProcessWithoutNullStreams | undefined): Promise<void> {
+  if (child === undefined || child.exitCode !== null) return
+  child.kill('SIGINT')
+  if (await exitsWithin(child, 5_000)) return
+  child.kill('SIGTERM')
+  if (!await exitsWithin(child, 5_000)) throw new Error('DSH Web did not stop after SIGINT and SIGTERM')
+}
+
+function exitsWithin(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null) return Promise.resolve(true)
+  return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      child.removeListener('exit', exited)
+      resolve(false)
+    }, timeoutMs)
+    function exited(): void {
+      clearTimeout(timer)
+      resolve(true)
+    }
+    child.once('exit', exited)
+  })
+}
+
+async function stableAria(locator: Locator): Promise<string> {
+  let previous = await locator.ariaSnapshot()
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await new Promise(resolve => { setTimeout(resolve, 100) })
+    const current = await locator.ariaSnapshot()
+    if (current === previous) return normalizeAria(current)
+    previous = current
+  }
+  throw new Error('learning-view aria snapshot did not stabilize')
+}
+
+function normalizeAria(value: string): string {
+  return value
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '{{uuid}}')
+    .replace(/\d{4}\/\d{1,2}\/\d{1,2} \d{2}:\d{2}:\d{2}/g, '{{clock}}')
+}
+
+async function compareOrRefresh(actual: string): Promise<void> {
+  const payload = `${actual}\n`
+  if (snapshotMode() === 'refresh') {
+    await writeFile(UI_GOLDEN, payload)
+    return
+  }
+  if (!existsSync(UI_GOLDEN)) {
+    throw new Error(`missing ${UI_GOLDEN}; run pnpm run test:web:refresh`)
+  }
+  expect(payload).toBe(await readFile(UI_GOLDEN, 'utf8'))
+}
+
+describe('keyless assembled DSH Web learning view', () => {
+  let root: string
+  let dshHome: string
+  let workspace: string
+  let host: ChildProcessWithoutNullStreams | undefined
+  let browser: Browser | undefined
+  let page: Page | undefined
+  const pageErrors: string[] = []
+
+  beforeAll(async () => {
+    const dshSource = requireDshSource()
+    root = await realpath(await mkdtemp(join(tmpdir(), 'dsh-explain-web-snapshot-')))
+    dshHome = join(root, 'home')
+    workspace = join(root, 'workspace')
+    await mkdir(workspace, { recursive: true })
+    runDsh(dshSource, dshHome, ['plugin', '--profile', 'web', 'add', REPOSITORY])
+    await writeFile(join(dshHome, 'profiles/web/cordis.patch.yml'), [
+      '- id: directory-picker',
+      '  disabled: true',
+      '- insert:',
+      '    - id: directory-picker-browse',
+      "      name: '@deepseek-ai/dsh-host-directory-picker-browse'",
+      '',
+    ].join('\n'))
+    await seedLearningDatabase(dshHome)
+    await seedDshSession(dshSource, dshHome, workspace)
+    const port = await freePort()
+    host = await startDsh(dshSource, dshHome, port)
+    browser = await chromium.launch()
+    page = await browser.newPage({
+      viewport: { width: 1680, height: 1000 },
+      locale: 'zh-CN',
+      timezoneId: 'UTC',
+    })
+    page.on('pageerror', error => { pageErrors.push(String(error)) })
+    await page.goto(`http://127.0.0.1:${port}`, { waitUntil: 'load' })
+    const continueButton = page.getByRole('button', { name: '继续' })
+    await continueButton.waitFor({ timeout: 15_000 })
+    await continueButton.click()
+    expect(await page.getByRole('tab', { name: '学习' }).count()).toBe(0)
+    const session = page.getByRole('treeitem', { name: /workspace 刚刚/ })
+    try {
+      await session.waitFor({ timeout: 15_000 })
+    } catch (error) {
+      throw new Error(`seeded Session did not appear\n${await page.locator('body').ariaSnapshot()}`, { cause: error })
+    }
+    await session.click()
+    const learning = page.getByRole('tab', { name: '学习' })
+    await learning.waitFor({ timeout: 15_000 })
+    expect(await learning.count()).toBe(1)
+    await learning.click()
+    await page.getByRole('heading', { name: '全局学习线程' }).waitFor({ timeout: 15_000 })
+    await page.getByRole('textbox', { name: '给智能体发消息' }).waitFor({ timeout: 15_000 })
+  }, 120_000)
+
+  afterAll(async () => {
+    const failures: unknown[] = []
+    await browser?.close().catch(error => { failures.push(error) })
+    await stopDsh(host).catch(error => { failures.push(error) })
+    if (root !== undefined) await rm(root, { recursive: true, force: true }).catch(error => { failures.push(error) })
+    if (failures.length === 1) throw failures[0]
+    if (failures.length > 1) throw new AggregateError(failures, 'web snapshot cleanup failed')
+  })
+
+  it('renders the global context and another source active card while disabled', async () => {
+    if (page === undefined) throw new Error('web page is not initialized')
+    const view = page.getByTestId('dsh-explain-learning-view')
+    const snapshot = await stableAria(view)
+    await compareOrRefresh(snapshot)
+    expect(snapshot).toContain('学习模式当前已关闭；历史仍可阅读。')
+    expect(snapshot).toContain('正在学习 TypeScript 的可辨识联合。')
+    expect(snapshot).toContain('其他会话的活跃讲解')
+    expect(await view.getByRole('button', { name: '✓ 懂了' }).isDisabled()).toBe(true)
+    expect(pageErrors).toEqual([])
+  })
+
+  it('keeps the fixture inventory closed', async () => {
+    expect((await readdir(SNAPSHOT_DIRECTORY)).sort()).toEqual(['session.jsonl', 'ui.expected.md'])
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,8 @@
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
-const dependency = (path: string): string => fileURLToPath(new URL(`./node_modules/${path}`, import.meta.url))
-const localReact = (path: string): string => dependency(`.pnpm/react@18.3.1/node_modules/react/${path}`)
-const localReactDom = (path: string): string => dependency(`.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/${path}`)
+const require = createRequire(import.meta.url)
 
 export default defineConfig({
   resolve: {
@@ -18,14 +17,9 @@ export default defineConfig({
         find: /^@deepseek-ai\/dsh-client-runtime\/client$/,
         replacement: fileURLToPath(new URL('./tests/client-runtime-stub.ts', import.meta.url)),
       },
-      { find: /^react$/, replacement: localReact('index.js') },
-      { find: /^react\/jsx-runtime$/, replacement: localReact('jsx-runtime.js') },
-      { find: /^react\/jsx-dev-runtime$/, replacement: localReact('jsx-dev-runtime.js') },
-      { find: /^react-dom$/, replacement: localReactDom('index.js') },
-      {
-        find: /^react-dom\/(.*)$/,
-        replacement: `${dependency('.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom')}/$1`,
-      },
+      { find: /^react$/, replacement: require.resolve('react') },
+      { find: /^react\/jsx-runtime$/, replacement: require.resolve('react/jsx-runtime') },
+      { find: /^react\/jsx-dev-runtime$/, replacement: require.resolve('react/jsx-dev-runtime') },
     ],
   },
   test: {

--- a/vitest.web.config.ts
+++ b/vitest.web.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/web.snapshot.ts'],
+    hookTimeout: 120_000,
+    testTimeout: 60_000,
+    sequence: { concurrent: false },
+  },
+})


### PR DESCRIPTION
## Summary

- add a 20-item P0 acceptance matrix and close the PRD/architecture review status
- add a keyless assembled DSH Web snapshot that installs the local plugin into a fresh DSH_HOME and checks the learning view composition
- cover disabled mode, idle/pressure compaction, in-flight fencing, disk restart restoration, and source observation isolation
- resolve React test identity through the linked DSH host instead of pnpm internal paths

## Validation

- pnpm run typecheck
- pnpm test (44 tests)
- DSH_SOURCE_DIR=/Users/yuezengwu/Projects/dsh pnpm run test:web (2 assembled Web tests)
- DSH_SOURCE_DIR=/Users/yuezengwu/Projects/dsh pnpm run dsh:link:check
- DSH_SOURCE_DIR=/Users/yuezengwu/Projects/dsh npm pack --dry-run
- git diff --check

M2 real-model browser evidence remains attached to private PR #2.