### PR TITLE
fix: blend learning view into composer

### DIFF
--- a/src/client/LearningView.tsx
+++ b/src/client/LearningView.tsx
@@ -46,7 +46,11 @@ export function LearningView({
   }
 
   return (
-    <div className="dsh-explain-root" data-testid="dsh-explain-learning-view">
+    <div
+      className="dsh-explain-root"
+      data-conversation-composer-overlay=""
+      data-testid="dsh-explain-learning-view"
+    >
       <main className="dsh-explain-shell">
         <header className="dsh-explain-heading">
           <div>

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -1,6 +1,6 @@
 /** Browser stylesheet injected and removed with the client plugin fiber. */
 export const LEARNING_VIEW_CSS = `
-.dsh-explain-root{box-sizing:border-box;height:100%;min-height:0;width:100%;overflow:auto;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-layer-1);padding:24px 24px calc(var(--dsh-composer-height,152px) + 32px)}
+.dsh-explain-root{box-sizing:border-box;height:100%;min-height:0;width:100%;overflow:auto;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-base);padding:24px 24px calc(var(--dsh-composer-height,152px) + 32px)}
 .dsh-explain-shell{width:min(900px,100%);margin:0 auto;display:flex;flex-direction:column;gap:20px}
 .dsh-explain-heading{display:flex;align-items:flex-start;justify-content:space-between;gap:16px}
 .dsh-explain-heading h1{font:var(--dsw-font-title-2);margin:0}

--- a/tests/client.spec.tsx
+++ b/tests/client.spec.tsx
@@ -119,6 +119,7 @@ describe('conversation learning view', () => {
     } as unknown as ComponentProps<typeof LearningView>
 
     const mounted = render(React.createElement(LearningView, props))
+    expect(mounted.container.querySelector('[data-conversation-composer-overlay]')).toBeTruthy()
     expect(screen.getByRole('heading', { name: '全局学习线程' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: 'Current concept' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: 'Other concept' })).toBeTruthy()


### PR DESCRIPTION
## What changed

- opt the learning tab into the host conversation composer-overlay layout;
- use the host base background token for one continuous surface in dark and light themes;
- cover the overlay marker in the client test.

## Root cause

The learning view used an elevated `layer-1` surface while the host composer fade used `bg-base`, and the view had not declared the official composer-overlay marker. The bottom of the learning scroller and the input seat were therefore painted and scrolled as separate regions.

## Validation

- `pnpm test` — 7 files, 48 tests
- `pnpm run typecheck`
- `DSH_SOURCE_DIR=/Users/yuezengwu/Projects/dsh pnpm run test:web` — 3 assembled Web tests
- real built Web UI with fresh local state and real main/auxiliary `deepseek-v4-flash` rounds

## Real candidate demo

![Learning view and composer visual seam](https://github.com/dsh-external/dsh-explain/blob/assets/m4-beta-controls/learning-composer-seam.gif?raw=true)

Provenance:

- explain candidate: `69275c39a4864e7ad86a04da707e2aa8d7ff0ef3`
- DSH source: `7b9644f2b664e46c9518506035aa6c8d5af4d8e8`
- fresh local data, agents, workspace, and session under `/tmp/dsh-explain-seam-demo.thviXC`
- built DSH Web UI over the normal Typert Remote; the official browser directory-picker pair was enabled for the scratch run
- real `deepseek-v4-flash` main-model round created and type-checked `src/state.ts`; a real auxiliary-model round generated the visible learning explanation
- no fixtures, mocks, seeded explanations, or test-only hooks
- computed layout check: learning and host backgrounds both `rgb(21, 21, 23)`, composer seat `absolute`, view overflow `hidden`
- GIF: 1200×676, 11.8 s, 581,598 bytes, SHA-256 `2eb2cb960cf26546f06c8c267d3def4503dd32f8f0c6258d6586ac0efd0d3278`
