### PR TITLE
Complete M6 optional plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # dsh-explain — Learning mode for DSH
 
-> ✅ **Status: the M6 Explain Host protocol is implemented and passes the automated gates. Optional consumer integrations are still in progress. The current minimum supported DSH version is `0.1.0-rc.6`.**
+> ✅ **Status: M6 implementation and four-plugin acceptance are complete on DSH `0.1.0-rc.6`. The consumer changes are ready as exact commits; publishing them upstream is pending repository write access.**
 > See the [product requirements](docs/PRD.md) and [technical architecture](docs/ARCHITECTURE.md) for the full design. The detailed design documents are currently written in Chinese.
 
 `dsh-explain` turns useful material from multiple [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) work sessions into one private, local-first learning thread. It keeps at most one active explanation per source session and continuously adapts explanations to the user's knowledge, preferences, and learning progress.
@@ -36,7 +36,7 @@
 
 - [x] Product overlap review: no direct duplicate was found; related plugins provide implementation references only.
 - [x] P0 PRD: one global thread, per-source active explanations, an autonomous-call budget, two compaction triggers, global `ExplainContext`, and automatable acceptance criteria.
-- [x] Architecture v9: the v8 manual-learning semantics plus a closed Host protocol for selections and suggested replies, exact source resolution, and persisted origin labels.
+- [x] Architecture v10: the v9 Host protocol plus public command discovery, click-time composer admission, consumer lifecycle invalidation, and four-plugin composition evidence.
 - [x] UI path: first-party `conversation.view` registration following the `ui-trajectory` view-ring pattern, with no external UI dependency.
 - [x] M1 infrastructure: standalone plugin build, local SQLite schema, entity-level CAS, pagination, long polling, and generated typed Remotes.
 - [x] M2 implementation: source observation, single-flight auxiliary scheduling, durable budgets, rephrasing, dual-trigger compaction, `ExplainContext`, and the Learning view.
@@ -45,13 +45,13 @@
 - [x] M4 configuration and diagnostics: settings UI without YAML editing, concurrent-setting convergence, source navigation and missing-source fallback, shared diagnostics store, and expanded assembled-Web snapshot.
 - [x] M5 manual learning command: `/explain <learning request>`, explicit-request scheduling, source labels, durable rephrase summaries, and stable failure results.
 - [x] M6.1 Explain Host protocol: `--selection` and `--suggested <turn>` source resolution, origin persistence, rephrase propagation, and stable failures.
-- [ ] M6 P1 optional integrations: selected text, suggested-reply learning actions, and visible Advisor suggestions enter the same learning loop through an editable `/explain` draft.
+- [x] M6 P1 implementation: selected text, suggested-reply learning actions, and visible Advisor suggestions enter the same learning loop through an editable `/explain` draft; keyless composition and a fresh real-model feedback loop pass.
 
 M1 established persistence and Host/Client RPC. M2 completed the learning loop. M3 added release gates. M4 made configuration, diagnostics, and source navigation available in the UI. M5 added user-initiated learning from the composer. M6 connects the same command protocol to optional plugin workflows. See the [acceptance matrix](docs/ACCEPTANCE.md) for automated evidence.
 
 ## Current iteration
 
-M6 integrates `dsh-selection-chat`, `dsh-suggested-replies`, and `dsh-advisor` through the public DSH command catalog and composer-write path. It does not read private data owned by those plugins or add automatic model calls. The scope, cross-repository order, design review, and acceptance criteria are recorded in [docs/NEXT.md](docs/NEXT.md).
+M6 integrates `dsh-selection-chat`, `dsh-suggested-replies`, and `dsh-advisor` through the public DSH command catalog and composer-write path. It does not read private data owned by those plugins or add automatic model calls. The implementation is validated at `dsh-selection-chat@90e9517`, `dsh-suggested-replies@0988019`, `dsh-advisor@2a3b011`, and DSH `47f9438`; the two `dsh-external` consumer repositories are read-only to this account and have forking disabled, so their local commits still require a maintainer to publish them. The scope and evidence are recorded in [docs/NEXT.md](docs/NEXT.md).
 
 ## Install
 
@@ -74,6 +74,7 @@ DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link:check
 pnpm run test
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:m6
 pnpm run typecheck
 pnpm run build
 ```
@@ -81,6 +82,8 @@ pnpm run build
 The source checkout must match the `0.1.0-rc.6` public API surface. Compatibility layers for earlier private-preview package lines are not retained.
 
 `test:web` starts a real keyless DSH Web composition with a fresh temporary `$DSH_HOME`, a durable session fixture, and a pre-seeded Explain database. It compares the Learning and Settings ARIA output against golden snapshots and verifies native settings revisions, source navigation, and the missing-source fallback. To intentionally update the UI output, run `DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web:refresh` and review the snapshot diff.
+
+`test:m6` installs Explain, selection-chat, suggested-replies, and the exact Advisor compatibility commit into a fresh profile. It verifies one contribution per plugin, unchanged suggestion budgets, selection-to-draft behavior, and clean removal/reinstallation. By default, the two consumer repositories must be sibling directories; override them with `DSH_SELECTION_CHAT_DIR`, `DSH_SUGGESTED_REPLIES_DIR`, or `DSH_ADVISOR_DIR`.
 
 Install the development checkout directly rather than through npm:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 # dsh-explain — DSH 学习模式插件
 
-> ✅ **状态：M6 Explain Host 协议已实现并通过自动化门禁；可选消费方插件待接入。当前最低支持 DSH 0.1.0-rc.6。**
+> ✅ **状态：M6 实现与 DSH `0.1.0-rc.6` 四插件验收已完成。消费方改动已有精确提交；上游发布仍等待仓库写权限。**
 > 产品需求见 [docs/PRD.md](docs/PRD.md)；技术方案见 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)。
 
 **一句话定位**：把多个 DSH 工作会话中值得学习的内容汇入用户唯一的全局学习线程，为每个来源会话保留至多一个活跃讲解，并用全局学习上下文持续适配用户的知识水平和讲解偏好。
@@ -36,7 +36,7 @@
 
 - [x] 需求查重：产品目标无直接重复，相关插件可提供局部实现参考。
 - [x] PRD P0 定稿：单一学习线程、按来源活跃讲解、自主调用预算、双触发压缩、全局 ExplainContext 和可自动验证的验收标准。
-- [x] 技术架构 v9：保留 v8 主动学习语义，增加选中文本与预测回复的封闭 Host 协议、精确来源定位和来源标识。
+- [x] 技术架构 v10：在 v9 Host 协议上补齐公开命令发现、点击时 composer 准入、消费方生命周期失效和四插件组合证据。
 - [x] UI 路径核验：沿用第一方 `ui-trajectory` 的 `ctx.slots.inject('conversation.view', ...)` 注册方式，无外部 UI 依赖。
 - [x] M1 基础设施：独立插件构建、本地 SQLite schema、实体级 CAS、分页/长轮询和自动生成的 typed Remote。
 - [x] M2 主实现：来源观察、辅助模型单飞调度、持久预算、重讲、双触发压缩、ExplainContext 与 `conversation.view` 学习界面。
@@ -45,13 +45,13 @@
 - [x] M4 内测可控性：无 YAML 设置页、并发设置收敛、来源跳转/缺失降级、共享诊断 store 和扩展 assembled Web snapshot。
 - [x] M5 主动学习命令：composer 中的 `/explain <学习请求>`、显式请求调度、来源标识、持久重讲摘要和稳定失败结果。
 - [x] M6.1 Explain Host 协议：`--selection` / `--suggested <turn>` 来源定位、origin 持久化、重讲传播和稳定失败。
-- [ ] M6 P1 可选集成：选中文字、预测回复学习建议和 Advisor 可见建议经可编辑 `/explain` 草稿进入同一学习闭环。
+- [x] M6 P1 实现：选中文字、预测回复学习建议和 Advisor 可见建议经可编辑 `/explain` 草稿进入同一学习闭环；无密钥组合与全新真实模型反馈流程均通过。
 
 M1 建立持久层和 Host/Client RPC 基础；M2 完成学习闭环；M3 建立 P0 发布门禁；M4 让内测用户无需编辑 YAML 即可配置和诊断，并能从讲解返回仍存在的来源会话；M5 允许用户从工作 composer 主动发起一次学习；M6 把同一命令协议接入可选插件工作流。自动化证据见 [验收矩阵](docs/ACCEPTANCE.md)。
 
 ## 当前迭代
 
-M6 通过 DSH command 目录和 composer 公共写入路径集成 `dsh-selection-chat`、`dsh-suggested-replies` 与 `dsh-advisor`，不读取其他插件私有数据，也不增加自动模型调用；完整范围、跨仓库顺序、设计审查与验收标准见 [迭代记录](docs/NEXT.md)。
+M6 通过 DSH command 目录和 composer 公共写入路径集成 `dsh-selection-chat`、`dsh-suggested-replies` 与 `dsh-advisor`，不读取其他插件私有数据，也不增加自动模型调用。实现已在 `dsh-selection-chat@90e9517`、`dsh-suggested-replies@0988019`、`dsh-advisor@2a3b011` 和 DSH `47f9438` 上通过；当前账号对两个 `dsh-external` 消费方仓库只有只读权限且组织禁用 fork，因此仍需维护者发布对应本地提交。完整范围与证据见 [迭代记录](docs/NEXT.md)。
 
 ## 安装
 
@@ -74,6 +74,7 @@ DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link:check
 pnpm run test
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:m6
 pnpm run typecheck
 pnpm run build
 ```
@@ -81,6 +82,8 @@ pnpm run build
 源码 checkout 必须匹配 `0.1.0-rc.6` 的公开 API；插件不保留更早私有预览版本线的兼容层。
 
 `test:web` 使用全新临时 `$DSH_HOME`、持久 Session fixture 和预置 Explain SQLite 运行无密钥的真实 DSH Web 组合，并比对学习视图与设置页 ARIA golden；它还验证 native settings revision 写入、可用来源跳转和缺失来源降级。更新有意的界面输出时运行 `DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web:refresh` 并审查 snapshot diff。
+
+`test:m6` 把 Explain、selection-chat、suggested-replies 和精确 Advisor 兼容提交安装到全新 profile，验证每个插件只贡献一次、预测回复预算不变、选区只写草稿，以及卸载/重新安装完全收敛。默认要求两个消费方仓库位于同级目录；也可通过 `DSH_SELECTION_CHAT_DIR`、`DSH_SUGGESTED_REPLIES_DIR` 或 `DSH_ADVISOR_DIR` 覆盖。
 
 开发验收使用本地目录安装，不经过 npm：
 
@@ -97,7 +100,7 @@ dsh --profile web
 | 仓库 | 可复用部分 | 明确不复用的部分 |
 |---|---|---|
 | [dsh-auto-blame](https://github.com/dsh-external/dsh-auto-blame) | 回合结束后的后台模型调用、客户端反馈形态 | 外部自定义 Session 事件与 projection 不能作为本项目持久化方案 |
-| [dsh-advisor](https://github.com/dsh-external/dsh-advisor) | 转录增量、模型调用隔离、发射保护和配置 gateway | advisor 向主 agent 注入建议；explain 永不注入主模型 |
+| [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | 转录增量、模型调用隔离、发射保护和配置 gateway | advisor 向主 agent 注入建议；explain 永不注入主模型 |
 | [dsh-memory](https://github.com/dsh-external/dsh-memory) | 仓库命名覆盖长期记忆方向 | 当前只有占位 README，没有可复用服务或协议 |
 | [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) | 跨会话分层记忆、低频快照与用户可见管理经验 | 未公开 Cordis memory service，且快照进入主 Agent；explain 不依赖或读取其私有文件 |
 | DSH `compact-basic` / `token-meter` / LLM model info | 容量阈值策略、固定 token 估算和精确路由 `contextWindow` | 原生 compact 只修改单个 Session surface；explain 需要自有全局 SQLite compactor |

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -31,6 +31,7 @@
 pnpm run typecheck
 pnpm test
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:web
+DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run test:m6
 pnpm run build
 DSH_SOURCE_DIR=/absolute/path/to/dsh pnpm run dsh:link:check
 git diff --check
@@ -62,3 +63,16 @@ git diff --check
 | 5 | 自主预算豁免 | `scheduler.spec.ts` 与 `m2-store.spec.ts` 断言主动生成和后续重讲不增加 `auto_request_usage` |
 | 6 | 主 Agent 隔离 | command runtime 只写标准 command 生命周期；`m2-core.spec.ts` 的 source 捕获不改变 `deriveMessages()`，assembled 产品流程验证 composer 命令不形成主模型回答 |
 | 7 | 产品证据 | `pnpm run typecheck`、`pnpm test`、`pnpm run test:web`、本地目录安装 smoke 和 PR 内真实模型 GIF |
+
+## M6 P1 可选插件集成
+
+| # | 标准 | 自动化与产品证据 |
+|---:|---|---|
+| 1 | 可选发现 | selection-chat 与 suggested-replies 单元测试覆盖 Explain 缺失/出现、查询失败及命令目录刷新；只读取当前 Session 的 command 目录 |
+| 2 | 选区草稿 | selection-chat 测试覆盖单消息选区、换行保留、空草稿保护、Session/phase 竞态与不提交；`test:m6` 在真实 DSH Web 中验证精确草稿 |
+| 3 | 建议附件 | suggested-replies 测试证明附件不进入 sidecar、不是第四个候选、固定 ready turn，并在点击时复核 composer |
+| 4 | 调用预算 | 组合配置断言 `suggestionCount = 3`、`maxTokens = 384`、`timeoutMs = 15000`；rc.6 真实模型验证 `suggestionReasoningEffort = off` 后产生正文而不扩大预算 |
+| 5 | 生命周期 | 两个消费方覆盖 `commands/change`、`agent-preset/selected`、`connection/reset`、迟到查询与卸载清理 |
+| 6 | Advisor 隔离 | Explain Host 测试拒绝 Advisor 自动观察；真实流程只在用户选择其可见 context 后生成 `origin: selection` |
+| 7 | 四插件组合 | `test:m6` 在全新 profile 安装四插件，断言每项唯一贡献、无页面错误、完整卸载后消失并可精确恢复 |
+| 8 | 真实闭环 | DSH `47f9438`、Explain `ed25029`、selection-chat `90e9517`、suggested-replies `0988019`、Advisor `2a3b011` 完成真实模型的建议附件、Advisor 鼠标选区、草稿、学习卡、✗ 重讲和 ✓ 掌握六帧 GIF |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
-# dsh-explain 技术架构 v9
+# dsh-explain 技术架构 v10
 
-> 状态：**v9 M6 Explain Host 协议已实现并通过自动化门禁**（2026-08-13）。产品需求见 [PRD.md](./PRD.md)，实现证据见 [验收矩阵](./ACCEPTANCE.md)。
-> v9 保留 v8 的数据与 UI 结构，增加 `--selection` 与携带精确来源回合的 `--suggested` 封闭协议、来源定位和本地化标识；SQLite schema 不变，explanation payload 只扩展向后兼容的可选 `origin`。
+> 状态：**v10 M6 实现、四插件组合与真实模型闭环完成**（2026-08-14）。产品需求见 [PRD.md](./PRD.md)，实现证据见 [验收矩阵](./ACCEPTANCE.md)。
+> v10 保留 v9 的 Host 协议与数据格式，补齐消费方命令发现、点击时 composer 准入、生命周期失效、rc.6 短预测推理约束和组合卸载验证；SQLite schema 不变。
 
 ## 架构结论
 
@@ -228,6 +228,14 @@ interface ExplanationEntryPayload {
 - `--suggested <turn> <request>` 只读指定 turn，防止草稿停留期间的新回合使来源漂移。显式快捷入口允许 `completed` 或 `max-tokens` 结束回合，但不放宽自动 Observer 的 completed-only 规则。指定 turn 不存在或不合格时返回 `EXPLAIN_SOURCE_UNAVAILABLE`，不回退到其他回合。
 
 三种变体都不补扫其他 Session，也不持久化完整 assistant 或工具结果。selection 匹配只决定有界 capsule，reasoning 和工具参数不参与搜索；它们只有在用户选中文本本身进入标准 command 日志时才成为该次请求的一部分。
+
+### M6 可选消费方集成
+
+`dsh-selection-chat` 与 `dsh-suggested-replies` 只通过当前 Session 的 `remote.commands.list(sessionId)` 发现 `explain`，再通过公开 conversation input facade 写入草稿。两者不导入 Explain 包、不读取 SQLite/Remote DTO，也不调用 submit。按钮点击时重新读取当前 Session、`phase === 'plain'` 与空草稿，避免渲染后切换 Session、开始提交或用户输入造成覆盖。
+
+命令能力缓存分别响应 `commands/change`、对应 Session 的 `agent-preset/selected` 和全局 `connection/reset`；异步查询同时绑定 Session 与组件/选区 epoch，迟到结果不能恢复旧入口。selection-chat 保留单消息、单次消费、10,000 字符和换行的既有选区约束。suggested-replies 的“学习刚才的回答”是 ready 行附件，不是第四个模型候选；它读取 sidecar 已固定的 turn，不写 sidecar，不改变 `suggestionCount = 3`、`maxTokens = 384` 或 `timeoutMs = 15000`。
+
+DSH rc.6 默认模型推理强度会占用短结构化预测的输出预算，因此 suggested-replies 把辅助调用的 `suggestionReasoningEffort` 暴露为 Config，默认 `off`，并在内部 Agent 的 `agent/request` waterfall 中显式设置。这个兼容修复不增加 token/时间预算，也不影响主 Session 路由。Advisor 不建立运行时桥接；其 `source.kind = advisor` 可见 context 只有被用户真实选择后才经 selection-chat 进入一次 `/explain --selection` 请求。
 
 ## 全局调度
 
@@ -639,16 +647,16 @@ ctx.slots.inject('conversation.view', () => ctx.slots.register({
 | M3 发布门禁 | 单元/集成、keyless snapshot、真实流程 GIF、安装与组合 smoke | 所有 P0 验收标准通过后才标记可发布 |
 | M4 内测可控性 | 设置 revision/CAS、模型目录、来源导航、诊断状态和产品证据 | 用户无需编辑 YAML 即可配置启用，状态和来源路径可解释，M4 验收矩阵全部通过 |
 | M5 主动学习命令 | command/composer 入口、manual 调度、稳定失败、来源标识和产品证据 | 用户可显式生成一条不占自主额度的讲解，主 Agent 历史不变 |
-| M6 P1 可选集成 | selection/suggested Host 协议、命令目录发现、可编辑草稿和 Advisor 显式选择路径 | 可选插件不读私有状态、不自动提交、不增加后台调用，四插件组合可验收 |
+| M6 P1 可选集成 | selection/suggested Host 协议、命令目录发现、可编辑草稿和 Advisor 显式选择路径 | **已完成**：可选插件不读私有状态、不自动提交、不增加后台调用，四插件组合与真实反馈闭环通过 |
 
-## v8 → v9 修订说明
+## v9 → v10 修订说明
 
-| v8 | v9 |
+| v9 | v10 |
 |---|---|
-| 显式来源只有普通 manual | 扩展为 `manual | selection | suggested`，后续 rephrase 保留 origin，旧 payload 仍解释为自主 |
-| 所有主动请求都猜测最新 completed turn | selection 逆序匹配选中消息；suggested 封装精确 turn，来源失效明确失败 |
-| 显式与自动都只接受 completed | 显式精确来源还可接受 max-tokens；自动 Observer 保持 completed-only |
-| UI 只区分自主/主动 | 增加本地化“选中解释”与“学习建议”标识 |
+| Host 已定义 selection/suggested 协议 | 两个消费方通过公开命令目录发现 Explain，并只写可编辑草稿 |
+| 命令能力刷新未落实到消费方 | 覆盖命令、preset 与连接三类失效源，迟到查询受 Session/epoch 隔离 |
+| suggested 辅助调用继承 rc.6 默认推理强度 | 可配置 `suggestionReasoningEffort` 默认 `off`，保持 3/384/15000 预算不变 |
+| 单仓库协议测试 | 增加四插件全新 profile 的安装、唯一贡献、选区草稿与卸载/恢复测试，以及真实模型反馈闭环 |
 
 ## 架构决策记录
 
@@ -679,5 +687,6 @@ ctx.slots.inject('conversation.view', () => ctx.slots.register({
 | 2026-08-13 | 来源导航只使用公开 Session inventory/open API；来源缺失保留全局学习历史并稳定降级 |
 | 2026-08-13 | `/explain <request>` 复用 DSH command runtime，不进入主 Agent；主动请求优先、预算豁免，并以 `origin: 'manual'` 投影到全局学习线程 |
 | 2026-08-13 | M6 可选插件只经 command 目录发现 Explain，只填写可编辑草稿；selection 逆序定位文本，suggested 携带精确 turn 避免提交竞态 |
+| 2026-08-14 | M6 消费方在点击时重新执行 composer 准入；命令能力受三类生命周期事件失效，suggested 短预测默认关闭推理以保留固定输出预算 |
   Manual --> Ready: explanation / 稳定失败
   Manual --> Disabled: explain off / abort

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -2,7 +2,7 @@
 
 ## M6：P1 可选插件集成
 
-> 状态：**Explain Host 协议已实现并通过自动化门禁，消费方插件待接入**（2026-08-13）。设计基线为 `dsh-explain@f66051d`、`dsh-selection-chat@878bd59`、`dsh-suggested-replies@66d5e36` 与 `dsh-advisor@068c511`。
+> 状态：**方案、对抗性审查、实现、自动化与真实模型验收完成；上游消费方发布受权限阻塞**（2026-08-14）。验收基线为 DSH `47f9438`、`dsh-explain@ed25029`、`dsh-selection-chat@90e9517`、`dsh-suggested-replies@0988019` 与 `dsh-advisor@2a3b011`。
 
 ### 目标
 
@@ -42,9 +42,9 @@ revision 1 payload 的可选 `origin` 扩为 `manual | selection | suggested`；
 
 ### 3. `dsh-advisor`：显式解释建议
 
-P1 不让 explain 订阅 Advisor runtime，也不改变 Advisor 的 `inject/steer` 路由。Advisor 建议已经作为带 `source.kind = advisor` 的可见、可持久化 context 消息呈现；用户可用 `dsh-selection-chat` 选中建议正文，再走同一个 `--selection` 入口。
+P1 不让 explain 订阅 Advisor runtime，也不改变 Advisor 的 `inject/steer` 路由。Advisor 建议已经作为带 `source.kind = advisor` 的可见、可持久化 context 消息呈现；用户可用 `dsh-selection-chat` 选中建议正文，再走同一个 `--selection` 入口。Advisor 的 rc.6 包装兼容只把未解析的 `schemastery` peer 改为 DSH 已发布的 `@deepseek-ai/schemastery`，不改变建议行为；修复已提交到 [上游 PR #17](https://github.com/omdsh-dev/dsh-advisor/pull/17)。
 
-该用户手势是唯一桥接授权：普通 Observer 继续只接受真实用户消息和当前 turn 的 assistant/tool 内容，Advisor 消息不会自动成为自主候选、ExplainContext observation 或 Topic 状态。`--selection` 的显式文本可以进入 Explain Agent，但不会回写或影响 Advisor，也不会被注入主 Agent。P1 不修改 `dsh-advisor` 代码；它只进入四插件组合验收矩阵。
+该用户手势是唯一桥接授权：普通 Observer 继续只接受真实用户消息和当前 turn 的 assistant/tool 内容，Advisor 消息不会自动成为自主候选、ExplainContext observation 或 Topic 状态。`--selection` 的显式文本可以进入 Explain Agent，但不会回写或影响 Advisor，也不会被注入主 Agent。P1 不修改 `dsh-advisor` 的运行时建议行为；rc.6 仅需上文所述的包 peer 兼容修复。
 
 ### 调度、预算与隐私
 
@@ -59,12 +59,12 @@ P1 不让 explain 订阅 Advisor runtime，也不改变 Advisor 的 `inject/stee
 | 阶段 | 仓库 | 修改 | 完成门 |
 |---|---|---|---|
 | M6.1 | `dsh-explain` | 先定义 `--selection` / `--suggested <turn>` 解析、来源定位、origin 投影和稳定失败 | **已完成**：command/主消息隔离、精确来源匹配、旧 payload 兼容和 Scheduler 测试通过 |
-| M6.2 | `dsh-selection-chat` | 命令目录发现、Explain 动作、空草稿保护和本地化 | explain 缺失时无动作；存在时只填草稿；选区/忙态/热卸载通过 |
-| M6.3 | `dsh-suggested-replies` | ready 行附件气泡、命令目录发现和草稿保护 | 不改变模型候选数/sidecar/调用数；点击只填携带精确 turn 的 `--suggested` 草稿 |
-| M6.4 | `dsh-explain` | 合入两个已发布的集成行为、更新 PRD/Architecture/README 和组合 fixture | 单插件、任意两插件、四插件组合均可启动和卸载；无私有数据耦合 |
-| M6.5 | 四插件组合 | 真实 Advisor 建议选择、学习建议、普通选择、反馈闭环与 GIF | 同一候选提交上完成真实 DSH Web、真实模型、数据库与主 Session 证据 |
+| M6.2 | `dsh-selection-chat` | 命令目录发现、Explain 动作、空草稿保护和本地化 | **已完成 `90e9517`**：36 项测试；explain 缺失时无动作，存在时只填草稿，选区/忙态/生命周期通过 |
+| M6.3 | `dsh-suggested-replies` | ready 行附件气泡、命令目录发现、草稿保护和 rc.6 短预测推理约束 | **已完成 `0988019`**：66 项测试；候选数/sidecar/预算不变，点击只填精确 turn 草稿 |
+| M6.4 | `dsh-explain` | 更新 PRD/Architecture/README 并增加组合 fixture | **已完成**：全新 profile 唯一贡献、选区草稿、完整卸载与恢复通过 |
+| M6.5 | 四插件组合 | 真实 Advisor 建议选择、学习建议、反馈闭环与 GIF | **已完成**：真实 DSH Web/模型、SQLite 与主 Session 上完成六帧闭环 |
 
-这些仓库相互独立，不建立跨仓库 PR stack。先合入 explain 的命令协议，再分别合入两个 UI 消费方，最后回到 explain 完成组合验收；消费方在协议提交合入前用精确 SHA 进行测试，不能跟随移动的 `main`。
+这些仓库相互独立，不建立跨仓库 PR stack。验收始终固定精确 SHA，不跟随移动的 `main`。当前账号对 `dsh-external/dsh-selection-chat` 和 `dsh-external/dsh-suggested-replies` 只有 READ，且组织策略禁止 fork；本地提交已经完成但无法由本次工作直接推送或发 PR。Advisor 修复已在个人 fork 推送并提交上游 PR #17。Explain 仓库可正常提交、推送和合入。
 
 ### 审查结论
 
@@ -75,6 +75,17 @@ P1 不让 explain 订阅 Advisor runtime，也不改变 Advisor 的 `inject/stee
 - **不复制权威状态机**：UI 不预判 Topic、来源槽或 Scheduler 竞争；Host 的双重 gate 决定最终结果。
 - **不让草稿制造 TOCTOU**：suggested 草稿携带候选对应的精确 turn；提交后 Host 只读该 turn，无效时明确失败。
 - **无 DSH 核心修改**：当前 `command.list`、composer input facade、`conversation.input.dock` 和 context 行可选文本已足够；P1 不增加核心 slot。
+
+### 对抗性审查补充
+
+- **异步能力发现不得回写旧 Session**：每次 `commands.list(sessionId)` 都绑定当前 Session、当前选区或组件 epoch；Session 切换、新选区、卸载和后续查询会使旧响应失效。
+- **命令目录有三个独立失效源**：`commands/change` 使所有已观察 Session 重新查询，`agent-preset/selected` 只使对应 Session 重新查询，`connection/reset` 丢弃整代结果。查询失败一律隐藏增强入口，不影响原功能。
+- **渲染时 disabled 不是写入授权**：按钮点击时必须从 `conversation.input.for(scope).state.getSnapshot()` 重新检查 `phase === 'plain'` 与空草稿，再调用一次 `setDraft()`；不能只信任 React 上一帧或工具条打开时的状态。
+- **选区规范化不能破坏代码**：只统一 CRLF、不可见空格与行内重复空白，保留换行和至多两个连续空行；Explain Host 再用同一规则归一化请求。旧原型把全部空白折成单行，不能采用。
+- **suggested 附件不是第四个候选**：附件在 UI 中与模型生成候选分离，不写 sidecar，也不改变 `suggestionCount`、`maxTokens`、`timeoutMs` 或模型调用次数。rc.6 兼容只显式关闭短预测的推理块；旧原型对三项预算默认值的调整不进入 M6。
+- **精确 turn 必须来自 ready sidecar**：附件只为当前 ready revision 的 `turn` 生成草稿；草稿创建后即固定该 turn。新回合不会改写已存在草稿，Host 也不会在来源失效时回退到最新回合。
+- **生命周期资源必须随插件卸载**：DOM、样式、计时器、命令目录监听、sidecar watch 和 Session 订阅都由插件 effect 或组件 cleanup 释放；卸载后迟到的 RPC、Remote 事件或模型结果不得恢复入口。
+- **组合成本保持显式**：Advisor 与 suggested-replies 的既有辅助调用可能在同一主回合各发生一次；Explain 快捷入口本身保持零调用，只有用户提交草稿后才产生 Explain 请求。
 
 ### 验收标准
 
@@ -89,7 +100,7 @@ P1 不让 explain 订阅 Advisor runtime，也不改变 Advisor 的 `inject/stee
 9. Advisor 未被选择时绝不进入 Explain 请求、observation 或 ExplainContext；被选择后只进入该次 command 和私有来源摘要。
 10. 主 Session `deriveMessages()` 在快捷入口提交前后保持不变；只有标准 `command/run` / `command/done` 增量。
 11. 四插件同时启用时各自单插件测试、assembled Web snapshot、组合/HMR/卸载测试和总调用计数断言通过。
-12. 用户可完成「选中 Advisor 建议 → 解释 → 学习 Tab 查看 → ✗ 重讲 → ✓ 掌握」真实模型闭环，并以私有 GIF 留证。
+12. 用户可完成「选中 Advisor 建议 → 解释 → 学习 Tab 查看 → ✗ 重讲 → ✓ 掌握」真实模型闭环，并在合入 PR 中保存 GIF 与精确提交证据。
 
 ## M5：主动学习命令
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # dsh-explain PRD（P0 定稿）
 
-> 状态：**P0 定稿**（2026-08-13）。实现证据见 [验收矩阵](./ACCEPTANCE.md)。
-> 技术方案见 [ARCHITECTURE.md](./ARCHITECTURE.md)；本文档与架构 v9 同步。
+> 状态：**P0 定稿；M6 P1 快捷入口实现与组合验收完成**（2026-08-14）。实现证据见 [验收矩阵](./ACCEPTANCE.md)。
+> 技术方案见 [ARCHITECTURE.md](./ARCHITECTURE.md)；本文档与架构 v10 同步。
 
 ## 定位
 
@@ -43,7 +43,7 @@ explain 维护一份不进入主 Agent 的全局 `ExplainContext`，用来判断
 |---|---|
 | 全局开关 | `/explain on`、`/explain off`、`/explain status`；默认关闭，作用于整个 `$DSH_HOME` |
 | 主动学习 | composer 输入 `/explain <学习请求>`；请求不发送给主 Agent，由 explain agent 结合全局 `ExplainContext` 和当前来源最近一个合格回合生成一条不能 skip 的讲解 |
-| 可选快捷入口（P1） | selection-chat 填写 `/explain --selection <text>`；suggested-replies 填写 `/explain --suggested <turn> <request>`；都不自动提交、不覆盖非空草稿，Advisor 只经用户显式选中进入 |
+| 可选快捷入口（P1，M6 已实现） | selection-chat 填写 `/explain --selection <text>`；suggested-replies 填写 `/explain --suggested <turn> <request>`；都不自动提交、不覆盖非空草稿，Advisor 只经用户显式选中进入 |
 | 自主选题 | 只观察顶层 Session 中正常完成且包含非空 assistant 输出的回合；explain 可以返回“不讲” |
 | 来源讲解槽 | 每个来源 Session 最多一个活跃讲解，可以没有；有活跃讲解时仍保留本来源最新一个候选 |
 | 全局单飞 | 全局最多一个辅助模型请求；主动请求、重讲、压缩和自主候选按明确优先级串行执行 |

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test": "vitest run",
     "test:web": "pnpm build && vitest run --config vitest.web.config.ts",
     "test:web:refresh": "pnpm build && DSH_SNAPSHOT=refresh vitest run --config vitest.web.config.ts",
+    "test:m6": "pnpm build && vitest run --config vitest.m6.config.ts",
     "prepare": "pnpm build"
   },
   "peerDependencies": {

--- a/tests/m6-combination.snapshot.ts
+++ b/tests/m6-combination.snapshot.ts
@@ -1,0 +1,252 @@
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { createServer } from 'node:net'
+import { existsSync, realpathSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium, type Browser, type Page } from 'playwright'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const REPOSITORY = fileURLToPath(new URL('..', import.meta.url))
+const SESSION_FIXTURE = join(REPOSITORY, 'tests/snapshots/learning-view/session.jsonl')
+const SESSION_ID = 'm6-combination-session'
+
+interface PluginSpec {
+  readonly marker: string
+  readonly packageName: string
+  readonly installSpec: string
+}
+
+function requireDirectory(envName: string, fallback: string, expected: string): string {
+  const candidate = process.env[envName]?.trim() || fallback
+  if (!existsSync(join(candidate, expected))) {
+    throw new Error(`${envName} must point to a built repository containing ${expected}: ${candidate}`)
+  }
+  return realpathSync(candidate)
+}
+
+function dshEnvironment(dshHome: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    DSH_HOME: dshHome,
+    DSH_TELEMETRY_DISABLED: '1',
+    DEEPSEEK_API_KEY: '',
+  }
+}
+
+function dshArgs(dshSource: string, args: readonly string[]): string[] {
+  return ['--import', 'tsx/esm', join(dshSource, 'apps/cli/src/bin.ts'), ...args]
+}
+
+function runDsh(dshSource: string, dshHome: string, args: readonly string[]): string {
+  return execFileSync(process.execPath, dshArgs(dshSource, args), {
+    cwd: dshSource,
+    env: dshEnvironment(dshHome),
+    encoding: 'utf8',
+    stdio: 'pipe',
+  })
+}
+
+function count(value: string, fragment: string): number {
+  return value.split(fragment).length - 1
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const probe = createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      if (address === null || typeof address === 'string') {
+        probe.close(() => { reject(new Error('port probe returned no address')) })
+        return
+      }
+      probe.close(() => { resolvePort(address.port) })
+    })
+  })
+}
+
+async function startDsh(dshSource: string, dshHome: string, port: number): Promise<ChildProcessWithoutNullStreams> {
+  const child = spawn(process.execPath, dshArgs(dshSource, ['--profile', 'web', '--port', String(port)]), {
+    cwd: dshSource,
+    env: dshEnvironment(dshHome),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  let output = ''
+  child.stdout.on('data', (chunk: Buffer) => { output += chunk.toString() })
+  child.stderr.on('data', (chunk: Buffer) => { output += chunk.toString() })
+  await new Promise<void>((resolveReady, reject) => {
+    const timer = setTimeout(() => { reject(new Error(`DSH Web did not start\n${output}`)) }, 45_000)
+    const poll = setInterval(() => {
+      if (!output.includes(`dsh web: http://127.0.0.1:${port}`)) return
+      clearTimeout(timer)
+      clearInterval(poll)
+      resolveReady()
+    }, 25)
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      clearInterval(poll)
+      reject(new Error(`DSH Web exited before readiness (${String(code ?? signal)})\n${output}`))
+    })
+  })
+  return child
+}
+
+async function stopDsh(child: ChildProcessWithoutNullStreams | undefined): Promise<void> {
+  if (child === undefined || child.exitCode !== null) return
+  child.kill('SIGINT')
+  await new Promise<void>((resolveExit, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error('DSH Web did not unload after SIGINT'))
+    }, 10_000)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolveExit()
+    })
+  })
+}
+
+async function seedSession(dshSource: string, dshHome: string, workspace: string): Promise<void> {
+  execFileSync(process.execPath, [join(REPOSITORY, 'tests/seed-web-session.mjs')], {
+    cwd: REPOSITORY,
+    env: {
+      ...dshEnvironment(dshHome),
+      DSH_SOURCE_DIR: dshSource,
+      DSH_WEB_FIXTURE: SESSION_FIXTURE,
+      DSH_WEB_SESSION_ID: SESSION_ID,
+      DSH_WEB_WORKSPACE: workspace,
+    },
+    encoding: 'utf8',
+    stdio: 'pipe',
+  })
+}
+
+async function finishOnboarding(page: Page): Promise<void> {
+  await page.getByRole('button', { name: '继续', exact: true }).click()
+  await page.locator('[class*="onboardingStage"]').waitFor({ state: 'detached', timeout: 15_000 })
+  await page.getByRole('button', { name: '稍后配置', exact: true }).click()
+}
+
+describe('M6 four-plugin composition', () => {
+  let root: string
+  let dshHome: string
+  let dshSource: string
+  let host: ChildProcessWithoutNullStreams | undefined
+  let browser: Browser | undefined
+  let page: Page | undefined
+  let plugins: readonly PluginSpec[]
+  const pageErrors: string[] = []
+
+  beforeAll(async () => {
+    dshSource = requireDirectory('DSH_SOURCE_DIR', '', 'apps/cli/src/bin.ts')
+    plugins = [
+      {
+        marker: '# == dsh-explain',
+        packageName: 'dsh-explain',
+        installSpec: REPOSITORY,
+      },
+      {
+        marker: '# == dsh-selection-chat',
+        packageName: 'dsh-selection-chat',
+        installSpec: requireDirectory('DSH_SELECTION_CHAT_DIR', resolve(REPOSITORY, '../dsh-selection-chat'), 'client.js'),
+      },
+      {
+        marker: '# == @dsh-external/dsh-suggested-replies',
+        packageName: '@dsh-external/dsh-suggested-replies',
+        installSpec: requireDirectory('DSH_SUGGESTED_REPLIES_DIR', resolve(REPOSITORY, '../dsh-suggested-replies'), 'lib/client.js'),
+      },
+      {
+        marker: '# == dsh-advisor',
+        packageName: 'dsh-advisor',
+        installSpec: process.env.DSH_ADVISOR_DIR?.trim()
+          || 'github:yuezengwu/dsh-advisor#2a3b011f0994e85882be5b9036d96d1462569328',
+      },
+    ]
+    root = await mkdtemp(join(tmpdir(), 'dsh-explain-m6-combination-'))
+    dshHome = join(root, 'home')
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace, { recursive: true })
+    for (const plugin of plugins) runDsh(dshSource, dshHome, ['plugin', '--profile', 'web', 'add', plugin.installSpec])
+    await writeFile(join(dshHome, 'profiles/web/cordis.patch.yml'), [
+      '- id: directory-picker',
+      '  disabled: true',
+      '- insert:',
+      '    - id: directory-picker-browse',
+      "      name: '@deepseek-ai/dsh-host-directory-picker-browse'",
+      '',
+    ].join('\n'))
+    await seedSession(dshSource, dshHome, workspace)
+    const port = await freePort()
+    host = await startDsh(dshSource, dshHome, port)
+    browser = await chromium.launch()
+    page = await browser.newPage({ viewport: { width: 1440, height: 920 }, locale: 'zh-CN' })
+    page.on('pageerror', error => { pageErrors.push(String(error)) })
+    await page.goto(`http://127.0.0.1:${port}`, { waitUntil: 'load' })
+    await finishOnboarding(page)
+    const workspaceItem = page.getByRole('treeitem', { name: 'workspace', exact: true })
+    await workspaceItem.waitFor({ timeout: 15_000 })
+    if (await workspaceItem.getAttribute('aria-expanded') !== 'true') await workspaceItem.click()
+    const session = page.locator('[role="treeitem"][aria-selected="false"]').filter({ hasText: 'workspace' })
+    await session.waitFor({ timeout: 15_000 })
+    await session.click()
+  }, 180_000)
+
+  afterAll(async () => {
+    const failures: unknown[] = []
+    await browser?.close().catch(error => { failures.push(error) })
+    await stopDsh(host).catch(error => { failures.push(error) })
+    if (root !== undefined) await rm(root, { recursive: true, force: true }).catch(error => { failures.push(error) })
+    if (failures.length === 1) throw failures[0]
+    if (failures.length > 1) throw new AggregateError(failures, 'M6 combination cleanup failed')
+  })
+
+  it('assembles each plugin once without changing suggested-replies budgets', () => {
+    const dump = runDsh(dshSource, dshHome, ['--profile', 'web', '--dump-config'])
+    for (const plugin of plugins) expect(count(dump, plugin.marker), plugin.marker).toBe(1)
+    expect(dump).toContain('suggestionCount: 3')
+    expect(dump).toContain('maxTokens: 384')
+    expect(dump).toContain('timeoutMs: 15000')
+    expect(dump).toContain("suggestionReasoningEffort: 'off'")
+  })
+
+  it('discovers Explain from a legal selected message and only fills the draft', async () => {
+    if (page === undefined) throw new Error('Web page is not initialized')
+    await page.getByRole('tab', { name: '学习', exact: true }).waitFor({ timeout: 15_000 })
+    await page.getByRole('tab', { name: '选区', exact: true }).waitFor({ timeout: 15_000 })
+    const text = '判别字段帮助 TypeScript 确定联合成员。'
+    const message = page.getByText(text, { exact: true })
+    await message.waitFor({ timeout: 15_000 })
+    await message.evaluate((node) => {
+      const selection = window.getSelection()
+      const range = document.createRange()
+      range.selectNodeContents(node)
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      node.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    })
+    const explain = page.getByRole('button', { name: '解释', exact: true })
+    await explain.waitFor({ timeout: 15_000 })
+    await explain.click()
+    const composer = page.getByRole('textbox', { name: '给智能体发消息' })
+    await expect.poll(() => composer.inputValue()).toBe(`/explain --selection ${text}`)
+    expect(await page.getByText(text, { exact: true }).count()).toBe(1)
+    expect(pageErrors).toEqual([])
+  })
+
+  it('removes and restores every plugin layer cleanly after Web unload', async () => {
+    await browser?.close()
+    browser = undefined
+    await stopDsh(host)
+    host = undefined
+    for (const plugin of [...plugins].reverse()) {
+      runDsh(dshSource, dshHome, ['plugin', '--profile', 'web', 'remove', plugin.packageName])
+    }
+    const removed = runDsh(dshSource, dshHome, ['--profile', 'web', '--dump-config'])
+    for (const plugin of plugins) expect(removed).not.toContain(plugin.marker)
+    for (const plugin of plugins) runDsh(dshSource, dshHome, ['plugin', '--profile', 'web', 'add', plugin.installSpec])
+    const restored = runDsh(dshSource, dshHome, ['--profile', 'web', '--dump-config'])
+    for (const plugin of plugins) expect(count(restored, plugin.marker), plugin.marker).toBe(1)
+  }, 90_000)
+})

--- a/vitest.m6.config.ts
+++ b/vitest.m6.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/m6-combination.snapshot.ts'],
+    hookTimeout: 180_000,
+    testTimeout: 90_000,
+    sequence: { concurrent: false },
+  },
+})


### PR DESCRIPTION
## Summary

- close the M6 optional-consumer design after adversarial review
- add a fresh-profile four-plugin composition gate for Explain, selection-chat, suggested-replies, and Advisor
- verify command discovery, selection-to-draft behavior, fixed suggestion budgets, and clean unload/reinstall
- document the exact DSH rc.6 and consumer commits used for acceptance

## Exact composition

- DSH `47f943859bef60e4160492346772ded9b24f765a`
- Explain host `ed25029189db2c5d1a9a1f80ac6af4609431efc2`
- selection-chat `90e9517f8a9f5c112d626f563938aa8f964c5890`
- suggested-replies `09880190f6d2937f3b9fc7994e00a8ad74f7bbb7`
- Advisor `2a3b011f0994e85882be5b9036d96d1462569328` ([upstream PR #17](https://github.com/omdsh-dev/dsh-advisor/pull/17))

The selection-chat and suggested-replies commits are complete locally, but this account has only read access to their `dsh-external` repositories and organization forking is disabled. Their publication therefore remains a maintainer action; the acceptance gate installs their exact local checkouts.

## Verification

- `pnpm run typecheck`
- `pnpm run test` — 59 tests
- `DSH_SOURCE_DIR=/tmp/dsh-official-latest.CUnRHD/source pnpm run test:web` — 4 tests
- `DSH_SOURCE_DIR=/tmp/dsh-official-latest.CUnRHD/source pnpm run test:m6` — 3 tests
- `DSH_SOURCE_DIR=/tmp/dsh-official-latest.CUnRHD/source pnpm run dsh:link:check`
- `npm pack --dry-run --ignore-scripts`
- `git diff --cached --check`

## Real GUI evidence

Recorded from one fresh DSH home, workspace, session, and Explain database against the exact clean commits above, using the real DSH Web server and real DeepSeek model flow. The in-app browser could not complete native text selection, so the final capture used the repository's Playwright fallback with a real mouse drag; DOM Range was used only to measure character boxes.

![M6 real four-plugin learning flow](https://raw.githubusercontent.com/yuezengwu/dsh-explain/assets/m6-four-plugin-integration/pr-14/m6-four-plugin-real.gif)

Media provenance: `assets/m6-four-plugin-integration@a1ed7ed7d5ec4dddb71684d25467d95834dbeeee`; SHA-256 `3a7b4f44007e85c8deca8a11db74588b03668321a91d75c6b1d5ce2eef9fcc9f`.
